### PR TITLE
Added the `PrimaryText` component

### DIFF
--- a/packages/TorneloScoresheet/src/components/ErrorToast/ErrorToast.tsx
+++ b/packages/TorneloScoresheet/src/components/ErrorToast/ErrorToast.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Animated, Dimensions, Text, View } from 'react-native';
+import { Animated, Dimensions, View } from 'react-native';
 import { useError } from '../../context/ErrorContext';
 import Icon from 'react-native-vector-icons/MaterialIcons';
 import { styles } from './style';
+import PrimaryText, { FontWeight } from '../PrimaryText/PrimaryText';
 
 // A toast that renders the current state of the "ErrorContext"
 const ErrorToast: React.FC = () => {
@@ -54,9 +55,19 @@ const ErrorToast: React.FC = () => {
       <View style={styles.container}>
         <View style={styles.titleRow}>
           <Icon name="warning" style={styles.icon} size={30} color="white" />
-          <Text style={styles.errorTitle}>Error</Text>
+          <PrimaryText
+            size={20}
+            colour="white"
+            style={styles.errorTitle}
+            weight={FontWeight.Bold}
+            label="Error"
+          />
         </View>
-        <Text style={styles.text}>{internalError}</Text>
+        <PrimaryText
+          colour="white"
+          weight={FontWeight.SemiBold}
+          label={internalError}
+        />
       </View>
     </Animated.View>
   );

--- a/packages/TorneloScoresheet/src/components/ErrorToast/style.ts
+++ b/packages/TorneloScoresheet/src/components/ErrorToast/style.ts
@@ -26,14 +26,7 @@ export const styles = StyleSheet.create({
     marginRight: 8,
     marginBottom: 2,
   },
-  text: {
-    color: 'white',
-    fontWeight: '600',
-  },
   errorTitle: {
-    fontSize: 20,
-    color: 'white',
-    fontWeight: '700',
     marginBottom: 4,
   },
 });

--- a/packages/TorneloScoresheet/src/components/PrimaryText/PrimaryText.tsx
+++ b/packages/TorneloScoresheet/src/components/PrimaryText/PrimaryText.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { StyleProp, Text, TextStyle } from 'react-native';
+import { primary } from '../../style/font';
+
+export enum FontWeight {
+  Thin,
+  ExtraLight,
+  Light,
+  Regular,
+  Medium,
+  SemiBold,
+  Bold,
+  ExtraBold,
+  Black,
+}
+
+const fontWeightStyle = (
+  fontWeight?: FontWeight,
+): '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900' => {
+  switch (fontWeight) {
+    case FontWeight.Thin:
+      return '100';
+    case FontWeight.ExtraLight:
+      return '200';
+    case FontWeight.Light:
+      return '300';
+    case FontWeight.Regular:
+      return '400';
+    case FontWeight.Medium:
+      return '500';
+    case FontWeight.SemiBold:
+      return '600';
+    case FontWeight.Bold:
+      return '700';
+    case FontWeight.ExtraBold:
+      return '800';
+    case FontWeight.Black:
+      return '900';
+    case undefined:
+      return '400';
+  }
+};
+
+type PrimaryTextProps = {
+  label?: string;
+  weight?: FontWeight;
+  colour?: string;
+  size?: number;
+  style?: StyleProp<TextStyle>;
+};
+
+const PrimaryText: React.FC<PrimaryTextProps> = ({
+  label,
+  weight,
+  colour,
+  style,
+  size,
+  children,
+}) => {
+  return (
+    <Text
+      style={[
+        {
+          fontWeight: fontWeightStyle(weight),
+          fontFamily: primary,
+          color: colour,
+          fontSize: size,
+        },
+        style,
+      ]}>
+      {label}
+      {children}
+    </Text>
+  );
+};
+
+export default PrimaryText;

--- a/packages/TorneloScoresheet/src/components/Sheet/Sheet.tsx
+++ b/packages/TorneloScoresheet/src/components/Sheet/Sheet.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { Modal, Text, View } from 'react-native';
+import { Modal, View } from 'react-native';
+import { colours } from '../../style/colour';
 import IconButton from '../IconButton/IconButton';
+import PrimaryText, { FontWeight } from '../PrimaryText/PrimaryText';
 import { styles } from './style';
 
 /**
@@ -20,7 +22,12 @@ const Sheet: React.FC<SheetProps> = ({ visible, content, dismiss, title }) => {
       <View style={styles.backdrop}>
         <View style={styles.contentContainer}>
           <View style={styles.header}>
-            <Text style={styles.title}>{title}</Text>
+            <PrimaryText
+              size={30}
+              weight={FontWeight.Bold}
+              style={styles.title}
+              label={title}
+            />
             <IconButton
               style={styles.exitButton}
               icon="cancel"
@@ -28,7 +35,11 @@ const Sheet: React.FC<SheetProps> = ({ visible, content, dismiss, title }) => {
               onPress={dismiss}
             />
           </View>
-          <Text style={styles.content}>{content}</Text>
+          <PrimaryText
+            colour={colours.black}
+            style={styles.content}
+            label={content}
+          />
         </View>
       </View>
     </Modal>

--- a/packages/TorneloScoresheet/src/components/Sheet/style.ts
+++ b/packages/TorneloScoresheet/src/components/Sheet/style.ts
@@ -20,7 +20,6 @@ export const styles = StyleSheet.create({
     marginLeft: 20,
     marginRight: 20,
     marginBottom: 40,
-    color: 'black',
   },
   header: {
     display: 'flex',
@@ -31,8 +30,6 @@ export const styles = StyleSheet.create({
   },
   title: {
     paddingLeft: 20,
-    fontSize: 30,
-    fontWeight: '700',
   },
   exitButton: {
     padding: 20,

--- a/packages/TorneloScoresheet/src/components/Toolbar/Toolbar.tsx
+++ b/packages/TorneloScoresheet/src/components/Toolbar/Toolbar.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Image, StatusBar, Text, View } from 'react-native';
+import { Image, StatusBar, View } from 'react-native';
 import { useAppModeState } from '../../context/AppModeStateContext';
 import {
   colours,
@@ -10,6 +10,7 @@ import {
 import { BLACK_LOGO_IMAGE, WHITE_LOGO_IMAGE } from '../../style/images';
 import { AppMode } from '../../types/AppModeState';
 import IconButton from '../IconButton/IconButton';
+import PrimaryText, { FontWeight } from '../PrimaryText/PrimaryText';
 import Sheet from '../Sheet/Sheet';
 import { styles } from './style';
 
@@ -59,9 +60,12 @@ const Toolbar: React.FC = () => {
                 : WHITE_LOGO_IMAGE
             }
           />
-          <Text style={[styles.logoText, { color: currentTextColour }]}>
-            Tornelo
-          </Text>
+          <PrimaryText
+            colour={currentTextColour}
+            size={34}
+            weight={FontWeight.Bold}
+            label="Tornelo"
+          />
         </View>
         <IconButton
           icon="help"

--- a/packages/TorneloScoresheet/src/components/Toolbar/style.ts
+++ b/packages/TorneloScoresheet/src/components/Toolbar/style.ts
@@ -1,4 +1,3 @@
-import { primary as primaryFont } from '../../style/font';
 import { StyleSheet } from 'react-native';
 
 export const styles = StyleSheet.create({
@@ -20,10 +19,5 @@ export const styles = StyleSheet.create({
     width: 40,
     height: 44,
     marginRight: 24,
-  },
-  logoText: {
-    fontSize: 34,
-    fontFamily: primaryFont,
-    fontWeight: '700',
   },
 });

--- a/packages/TorneloScoresheet/src/pages/Main.tsx
+++ b/packages/TorneloScoresheet/src/pages/Main.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text } from 'react-native';
+import PrimaryText from '../components/PrimaryText/PrimaryText';
 import { useAppModeState } from '../context/AppModeStateContext';
 import { AppMode } from '../types/AppModeState';
 import EnterPgn from './EnterPgn/EnterPgn';
@@ -14,7 +14,7 @@ const Main: React.FC = () => {
     case AppMode.PariringSelection:
       return <PairingSelection />;
     default:
-      return <Text>Unsupported app mode</Text>;
+      return <PrimaryText label="Unsupported app mode" />;
   }
 };
 


### PR DESCRIPTION
This highly generic component lets us ensure that all text in the app is using Tornelo's primary font face: "Montserrat".

It also allows us to make styling text easier by having convenience props. So rather than having to have a specific style object for a piece of text, we can specify the font weight, size and colour directly via props.

This PR also introduces the `FontWeight` utility type, which makes it easy to specify the desired font weight on a PrimaryText component. Rather than specifying "400", "500", etc. we can now specify "Light", "Bold" etc, which is the terminology that Figma uses. All of this makes it easier to convert our Figma designs to code :))