### PR TITLE
Added the `Link` component

### DIFF
--- a/packages/TorneloScoresheet/src/components/Link/Link.tsx
+++ b/packages/TorneloScoresheet/src/components/Link/Link.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { Linking, Pressable, StyleProp, TextStyle } from 'react-native';
+import { useError } from '../../context/ErrorContext';
+import { colours } from '../../style/colour';
+import PrimaryText from '../PrimaryText/PrimaryText';
+import { styles } from './style';
+
+type LinkProps = {
+  link: string;
+  label: string;
+  style?: StyleProp<TextStyle>;
+};
+
+const Link: React.FC<LinkProps> = ({ label, link, style }) => {
+  const [, showError] = useError();
+  const followLink = async () => {
+    console.log('Going to', link);
+    if (!(await Linking.canOpenURL(link))) {
+      showError(`Don't know how to open url: ${link}`);
+    }
+    await Linking.openURL(link);
+  };
+  return (
+    <Pressable onPress={followLink}>
+      <PrimaryText
+        colour={colours.secondary}
+        style={[styles.linkText, style]}
+        label={label}
+      />
+    </Pressable>
+  );
+};
+
+export default Link;

--- a/packages/TorneloScoresheet/src/components/Link/style.ts
+++ b/packages/TorneloScoresheet/src/components/Link/style.ts
@@ -1,0 +1,7 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  linkText: {
+    textDecorationLine: 'underline',
+  },
+});


### PR DESCRIPTION
This component will allow us to render links to URLs in a consistent
manner.

This patch is to prepare for rendering the link to tornelo.com on the
EnterPGN page


![a Link in sentance](https://user-images.githubusercontent.com/57308619/166681933-254841a5-9197-471f-8b10-b5c44cedfd4a.png)