### PR TITLE
Graphical recording mode view

### DIFF
--- a/packages/TorneloScoresheet/__tests__/chessEngine.test.ts
+++ b/packages/TorneloScoresheet/__tests__/chessEngine.test.ts
@@ -1,5 +1,7 @@
 import moment from 'moment';
-import { parseGameInfo } from '../src/chessEngine';
+import { parseGameInfo, startGame } from '../src/chessEngine';
+import { PlayerColour } from '../src/types/ChessGameInfo';
+import { BoardPosition, Piece } from '../src/types/ChessMove';
 import { isError, succ } from '../src/types/Result';
 
 const pgnSuccess = `[Event "Skywalker Challenge - A"]
@@ -248,4 +250,28 @@ test('testParseRoundBoardGameAndRound', () => {
       ],
     }),
   );
+});
+
+test('testStartGame', () => {
+  const [board, startingFen] = startGame();
+  expect(startingFen).toStrictEqual(
+    'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+  );
+  expect(board.length).toStrictEqual(8);
+  const countPeices = (
+    board: BoardPosition[][],
+    color: PlayerColour,
+  ): number => {
+    let count = 0;
+    board.forEach(row => {
+      row.forEach(square => {
+        if (square.piece?.player === color) {
+          count += 1;
+        }
+      });
+    });
+    return count;
+  };
+  expect(countPeices(board, PlayerColour.White)).toStrictEqual(16);
+  expect(countPeices(board, PlayerColour.Black)).toStrictEqual(16);
 });

--- a/packages/TorneloScoresheet/src/components/Toolbar/Toolbar.tsx
+++ b/packages/TorneloScoresheet/src/components/Toolbar/Toolbar.tsx
@@ -25,7 +25,7 @@ const colourForMode: Record<AppMode, ColourType> = {
   [AppMode.EnterPgn]: colours.tertiary,
   [AppMode.PariringSelection]: colours.tertiary,
   [AppMode.TablePairing]: colours.primary,
-  [AppMode.PlayerScoresheetRecording]: colours.primary,
+  [AppMode.GraphicalRecording]: colours.primary,
   [AppMode.ResultDisplay]: colours.primary,
 };
 

--- a/packages/TorneloScoresheet/src/context/AppModeStateContext.tsx
+++ b/packages/TorneloScoresheet/src/context/AppModeStateContext.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useState } from 'react';
 import { makeUseEnterPgnState } from '../hooks/appMode/enterPgnState';
 import { makeUsePairingSelectionState } from '../hooks/appMode/pairingSelectionState';
+import { makeUseGraphicalRecordingState } from '../hooks/appMode/graphicalRecordingState';
 import { AppModeState, AppMode } from '../types/AppModeState';
 
 // The global state for the app
@@ -31,3 +32,5 @@ export const AppModeStateContextProvider: React.FC = ({ children }) => {
 export const useEnterPgnState = makeUseEnterPgnState(AppModeStateContext);
 export const usePairingSelectionState =
   makeUsePairingSelectionState(AppModeStateContext);
+export const useGraphicalRecordingState =
+  makeUseGraphicalRecordingState(AppModeStateContext);

--- a/packages/TorneloScoresheet/src/hooks/appMode/graphicalRecordingState.ts
+++ b/packages/TorneloScoresheet/src/hooks/appMode/graphicalRecordingState.ts
@@ -1,0 +1,42 @@
+import { useContext } from 'react';
+import {
+  AppMode,
+  AppModeState,
+  GraphicalRecordingMode,
+} from '../../types/AppModeState';
+
+type GraphicalRecordingStateHookType = [
+  GraphicalRecordingMode,
+  {
+    goToEndGame: () => void;
+    goToTextInput: () => void;
+    goToArbiterMode: () => void;
+  },
+];
+
+export const makeUseGraphicalRecordingState =
+  (
+    context: React.Context<
+      [AppModeState, React.Dispatch<React.SetStateAction<AppModeState>>]
+    >,
+  ): (() => GraphicalRecordingStateHookType | null) =>
+  (): GraphicalRecordingStateHookType | null => {
+    const [appModeState, setAppModeState] = useContext(context);
+
+    if (appModeState.mode !== AppMode.GraphicalRecording) {
+      return null;
+    }
+
+    const goToEndGameFunc = (): void => {};
+    const goToTextInputFunc = (): void => {};
+    const goToArbiterModeFunc = (): void => {};
+
+    return [
+      appModeState,
+      {
+        goToEndGame: goToEndGameFunc,
+        goToTextInput: goToTextInputFunc,
+        goToArbiterMode: goToArbiterModeFunc,
+      },
+    ];
+  };

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { View } from 'react-native';
+import ChessBoard from '../../components/ChessBoard/ChessBoard';
+import { useGraphicalRecordingState } from '../../context/AppModeStateContext';
+
+const GraphicalRecording: React.FC = () => {
+  const graphicalRecordingState = useGraphicalRecordingState();
+
+  const graphicalRecordingMode = graphicalRecordingState?.[0];
+  const goToEndGame = graphicalRecordingState?.[1].goToEndGame;
+  const goToTextInput = graphicalRecordingState?.[1].goToTextInput;
+  const goToArbiterMode = graphicalRecordingState?.[1].goToArbiterMode;
+
+  const endGame = () => {
+    if (!goToEndGame) {
+      return;
+    }
+    goToEndGame();
+  };
+
+  const textInput = () => {
+    if (!goToTextInput) {
+      return;
+    }
+    goToTextInput();
+  };
+
+  const arbiterMode = () => {
+    if (!goToArbiterMode) {
+      return;
+    }
+    goToArbiterMode();
+  };
+
+  return (
+    <>
+      {graphicalRecordingMode && (
+        <View>
+          <ChessBoard
+            flipBoard={false}
+            boardPositions={graphicalRecordingMode.board}
+          />
+        </View>
+      )}
+    </>
+  );
+};
+
+export default GraphicalRecording;

--- a/packages/TorneloScoresheet/src/pages/Main.tsx
+++ b/packages/TorneloScoresheet/src/pages/Main.tsx
@@ -3,6 +3,7 @@ import PrimaryText from '../components/PrimaryText/PrimaryText';
 import { useAppModeState } from '../context/AppModeStateContext';
 import { AppMode } from '../types/AppModeState';
 import EnterPgn from './EnterPgn/EnterPgn';
+import GraphicalRecording from './GraphicalRecording/GraphicalRecording';
 import PairingSelection from './PairingSelection/PairingSelection';
 
 const Main: React.FC = () => {
@@ -13,6 +14,8 @@ const Main: React.FC = () => {
       return <EnterPgn />;
     case AppMode.PariringSelection:
       return <PairingSelection />;
+    case AppMode.GraphicalRecording:
+      return <GraphicalRecording />;
     default:
       return <PrimaryText label="Unsupported app mode" />;
   }

--- a/packages/TorneloScoresheet/src/types/AppModeState.ts
+++ b/packages/TorneloScoresheet/src/types/AppModeState.ts
@@ -1,10 +1,12 @@
+import { ChessBoardPositions } from './ChessBoardPositions';
 import { ChessGameInfo } from './ChessGameInfo';
+import { ChessMove } from './ChessMove';
 
 export enum AppMode {
   EnterPgn,
   PariringSelection,
   TablePairing,
-  PlayerScoresheetRecording,
+  GraphicalRecording,
   ResultDisplay,
 }
 
@@ -22,14 +24,15 @@ export type TablePairingMode = {
   pairing: ChessGameInfo;
 };
 
-export type PlayerScoresheetRecordingMode = {
-  mode: AppMode.PlayerScoresheetRecording;
-  table: number;
-  scores: number[];
+export type GraphicalRecordingMode = {
+  mode: AppMode.GraphicalRecording;
+  pairing: ChessGameInfo;
+  moveHistory: ChessMove[];
+  board: ChessBoardPositions;
 };
 
 export type AppModeState =
   | EnterPgnMode
   | PairingSelectionMode
   | TablePairingMode
-  | PlayerScoresheetRecordingMode;
+  | GraphicalRecordingMode;

--- a/packages/TorneloScoresheet/src/types/ChessMove.ts
+++ b/packages/TorneloScoresheet/src/types/ChessMove.ts
@@ -16,13 +16,13 @@ export type Piece = {
 };
 
 export type MovePlie = {
-  from: Position;
-  to: Position;
-  fen: string;
+  from?: Position;
+  to?: Position;
+  startingFen: string;
 };
 
 export type ChessMove = {
   whiteMove: MovePlie;
-  blackMove: MovePlie;
+  blackMove?: MovePlie;
   moveNo: number;
 };


### PR DESCRIPTION
Created a new Page: `GraphicalRecordingMode`
This required the following changes:

1. Adding a new AppMode (GraphicalRecordingMode) and relevant data in state
2. adding a new State adn hook (useGraphicalRecordingstate())
3. Adding a new Page and styling
4. Edit chess engine to be able to start a new game
5. Edite chess engine to take in the game state and return an nested array of board postions (used by our chess board component to render the board - WE WILL NEVER PASS AROUND THE CHESS.js OBJECT ITSELF)

the Graphical Recording Page currently looks like this:
 
![graphical recording](https://user-images.githubusercontent.com/26475724/167061025-2c1b9e63-21a6-44e7-af9c-2f7c53078e85.PNG)

 