### PR TITLE
Updated pipeline file to allow for manual triggering

### DIFF
--- a/.github/workflows/ios_pipeline.yml
+++ b/.github/workflows/ios_pipeline.yml
@@ -8,6 +8,8 @@ name: Node.js CI
 on:
   pull_request_review:
     types: [submitted]
+  workflow_dispatch:
+  
 
 jobs:
   build:


### PR DESCRIPTION
We can now manually trigger a github actions workflow,
see https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow for instructions