### PR TITLE
Chess engine decoupling

### DIFF
--- a/packages/TorneloScoresheet/__tests__/chessEngine.test.ts
+++ b/packages/TorneloScoresheet/__tests__/chessEngine.test.ts
@@ -1,10 +1,11 @@
 import moment from 'moment';
-import { parseGameInfo, startGame } from '../src/chessEngine';
+import { chessEngine } from '../src/chessEngine/chessEngineInterface';
+import { ChessBoardPositions } from '../src/types/ChessBoardPositions';
 import { PlayerColour } from '../src/types/ChessGameInfo';
-import { BoardPosition, Piece } from '../src/types/ChessMove';
 import { isError, succ } from '../src/types/Result';
 
-const pgnSuccess = `[Event "Skywalker Challenge - A"]
+// ---- chessEngine.parseGameInfo() ----
+const pgnSucess = `[Event "Skywalker Challenge - A"]
 [Site "Prague, Czechia"]
 [Date "2021.09.12"]
 [Round "6.1"]
@@ -16,45 +17,6 @@ const pgnSuccess = `[Event "Skywalker Challenge - A"]
 
 *
 `;
-test('chessEngineParsePgnSuccess', () => {
-  let gameInfo = parseGameInfo(pgnSuccess);
-  expect(gameInfo).toEqual(
-    succ({
-      name: 'Skywalker Challenge - A',
-      site: 'Prague, Czechia',
-      round: 6,
-      board: 1,
-      result: '*',
-      date: moment('2021.09.12', 'YYYY.MM.DD'),
-      pgn: pgnSuccess,
-      players: [
-        {
-          color: 0,
-          firstName: ' Anakin',
-          lastName: 'Skywalker',
-          elo: 0,
-          country: '',
-          fideId: 600000,
-        },
-        {
-          color: 1,
-          firstName: ' Master',
-          lastName: 'Yoda',
-          elo: 0,
-          country: '',
-          fideId: 1000000,
-        },
-      ],
-    }),
-  );
-});
-
-const pgnFailure = '';
-test('chessEngineParsePgnFailure', () => {
-  let gameInfo = parseGameInfo(pgnFailure);
-  expect(isError(gameInfo)).toEqual(true);
-});
-
 const pgnNoFIdeId = `[Event "Skywalker Challenge - A"]
 [Site "Prague, Czechia"]
 [Date "2021.09.12"]
@@ -65,38 +27,6 @@ const pgnNoFIdeId = `[Event "Skywalker Challenge - A"]
 
 *
 `;
-test('chessEngineParsePgnNoFideId', () => {
-  let gameInfo = parseGameInfo(pgnNoFIdeId);
-  expect(gameInfo).toEqual(
-    succ({
-      name: 'Skywalker Challenge - A',
-      site: 'Prague, Czechia',
-      round: 6,
-      board: 1,
-      result: '*',
-      date: moment('2021.09.12', 'YYYY.MM.DD'),
-      pgn: pgnNoFIdeId,
-      players: [
-        {
-          color: 0,
-          firstName: ' Anakin',
-          lastName: 'Skywalker',
-          elo: 0,
-          country: '',
-          fideId: undefined,
-        },
-        {
-          color: 1,
-          firstName: ' Master',
-          lastName: 'Yoda',
-          elo: 0,
-          country: '',
-          fideId: undefined,
-        },
-      ],
-    }),
-  );
-});
 const pgnNoFirstName = `[Event "Skywalker Challenge - A"]
 [Site "Prague, Czechia"]
 [Date "2021.09.12"]
@@ -109,55 +39,6 @@ const pgnNoFirstName = `[Event "Skywalker Challenge - A"]
 
 *
 `;
-
-test('chessEngineParsePgnNoFirstName', () => {
-  let gameInfo = parseGameInfo(pgnNoFirstName);
-  expect(gameInfo).toEqual(
-    succ({
-      name: 'Skywalker Challenge - A',
-      site: 'Prague, Czechia',
-      round: 6,
-      board: 1,
-      result: '*',
-      date: moment('2021.09.12', 'YYYY.MM.DD'),
-      pgn: pgnNoFirstName,
-      players: [
-        {
-          color: 0,
-          firstName: ' ?',
-          lastName: 'Skywalker',
-          elo: 0,
-          country: '',
-          fideId: 600000,
-        },
-        {
-          color: 1,
-          firstName: ' ?',
-          lastName: 'Yoda',
-          elo: 0,
-          country: '',
-          fideId: 1000000,
-        },
-      ],
-    }),
-  );
-});
-
-const htmlString = `
-<!DOCTYPE html>
-<html lang="en">
-<head>
-</head>
-<body>
-</body>
-<footer>
-</footer>
-</html>`;
-
-test('chessEngineParseHtml', () => {
-  let gameInfo = parseGameInfo(htmlString);
-  expect(isError(gameInfo)).toEqual(true);
-});
 
 const pgnOnlyBoard = `[Event "Skywalker Challenge - A"]
 [Site "Prague, Czechia"]
@@ -172,39 +53,6 @@ const pgnOnlyBoard = `[Event "Skywalker Challenge - A"]
 *
 `;
 
-test('testParseRoundOnlyBoard', () => {
-  let gameInfo = parseGameInfo(pgnOnlyBoard);
-  expect(gameInfo).toEqual(
-    succ({
-      name: 'Skywalker Challenge - A',
-      site: 'Prague, Czechia',
-      board: 6,
-      round: undefined,
-      result: '*',
-      date: moment('2021.09.12', 'YYYY.MM.DD'),
-      pgn: pgnOnlyBoard,
-      players: [
-        {
-          color: 0,
-          firstName: ' Anakin',
-          lastName: 'Skywalker',
-          elo: 0,
-          country: '',
-          fideId: 600000,
-        },
-        {
-          color: 1,
-          firstName: ' Master',
-          lastName: 'Yoda',
-          elo: 0,
-          country: '',
-          fideId: 1000000,
-        },
-      ],
-    }),
-  );
-});
-
 const pgnBoardRoundGame = `[Event "Skywalker Challenge - A"]
 [Site "Prague, Czechia"]
 [Date "2021.09.12"]
@@ -218,48 +66,211 @@ const pgnBoardRoundGame = `[Event "Skywalker Challenge - A"]
 *
 `;
 
-test('testParseRoundBoardGameAndRound', () => {
-  let gameInfo = parseGameInfo(pgnBoardRoundGame);
-  expect(gameInfo).toEqual(
-    succ({
-      name: 'Skywalker Challenge - A',
-      site: 'Prague, Czechia',
-      board: 3,
-      game: 1,
-      round: 6,
-      result: '*',
-      date: moment('2021.09.12', 'YYYY.MM.DD'),
+describe('parseGameInfo', () => {
+  const testCases = [
+    {
+      name: 'ParsePgnSuccess',
+      pgn: pgnSucess,
+      shouldFail: false,
+      expectedResult: {
+        name: 'Skywalker Challenge - A',
+        site: 'Prague, Czechia',
+        round: 6,
+        board: 1,
+        result: '*',
+        date: moment('2021.09.12', 'YYYY.MM.DD'),
+        pgn: pgnSucess,
+        players: [
+          {
+            color: 0,
+            firstName: ' Anakin',
+            lastName: 'Skywalker',
+            elo: 0,
+            country: '',
+            fideId: 600000,
+          },
+          {
+            color: 1,
+            firstName: ' Master',
+            lastName: 'Yoda',
+            elo: 0,
+            country: '',
+            fideId: 1000000,
+          },
+        ],
+      },
+    },
+    {
+      name: 'empty pgn',
+      pgn: '',
+      shouldFail: true,
+    },
+    {
+      name: 'html instead of pgn',
+      pgn: `
+      <!DOCTYPE html>
+      <html lang="en">
+      <head>
+      </head>
+      <body>
+      </body>
+      <footer>
+      </footer>
+      </html>`,
+      shouldFail: true,
+    },
+    {
+      name: 'Pgn with no fideId',
+      shouldFail: false,
+      pgn: pgnNoFIdeId,
+      expectedResult: {
+        name: 'Skywalker Challenge - A',
+        site: 'Prague, Czechia',
+        round: 6,
+        board: 1,
+        result: '*',
+        date: moment('2021.09.12', 'YYYY.MM.DD'),
+        pgn: pgnNoFIdeId,
+        players: [
+          {
+            color: 0,
+            firstName: ' Anakin',
+            lastName: 'Skywalker',
+            elo: 0,
+            country: '',
+            fideId: undefined,
+          },
+          {
+            color: 1,
+            firstName: ' Master',
+            lastName: 'Yoda',
+            elo: 0,
+            country: '',
+            fideId: undefined,
+          },
+        ],
+      },
+    },
+    {
+      name: 'Pgn no first name',
+      shouldFail: false,
+      pgn: pgnNoFirstName,
+      expectedResult: {
+        name: 'Skywalker Challenge - A',
+        site: 'Prague, Czechia',
+        round: 6,
+        board: 1,
+        result: '*',
+        date: moment('2021.09.12', 'YYYY.MM.DD'),
+        pgn: pgnNoFirstName,
+        players: [
+          {
+            color: 0,
+            firstName: ' ?',
+            lastName: 'Skywalker',
+            elo: 0,
+            country: '',
+            fideId: 600000,
+          },
+          {
+            color: 1,
+            firstName: ' ?',
+            lastName: 'Yoda',
+            elo: 0,
+            country: '',
+            fideId: 1000000,
+          },
+        ],
+      },
+    },
+    {
+      name: 'pgn only board',
+      shouldFail: false,
+      pgn: pgnOnlyBoard,
+      expectedResult: {
+        name: 'Skywalker Challenge - A',
+        site: 'Prague, Czechia',
+        board: 6,
+        round: undefined,
+        result: '*',
+        date: moment('2021.09.12', 'YYYY.MM.DD'),
+        pgn: pgnOnlyBoard,
+        players: [
+          {
+            color: 0,
+            firstName: ' Anakin',
+            lastName: 'Skywalker',
+            elo: 0,
+            country: '',
+            fideId: 600000,
+          },
+          {
+            color: 1,
+            firstName: ' Master',
+            lastName: 'Yoda',
+            elo: 0,
+            country: '',
+            fideId: 1000000,
+          },
+        ],
+      },
+    },
+    {
+      name: 'Pgn board, round and game',
+      shouldFail: false,
       pgn: pgnBoardRoundGame,
-      players: [
-        {
-          color: 0,
-          firstName: ' Anakin',
-          lastName: 'Skywalker',
-          elo: 0,
-          country: '',
-          fideId: 600000,
-        },
-        {
-          color: 1,
-          firstName: ' Master',
-          lastName: 'Yoda',
-          elo: 0,
-          country: '',
-          fideId: 1000000,
-        },
-      ],
-    }),
-  );
+      expectedResult: {
+        name: 'Skywalker Challenge - A',
+        site: 'Prague, Czechia',
+        board: 3,
+        game: 1,
+        round: 6,
+        result: '*',
+        date: moment('2021.09.12', 'YYYY.MM.DD'),
+        pgn: pgnBoardRoundGame,
+        players: [
+          {
+            color: 0,
+            firstName: ' Anakin',
+            lastName: 'Skywalker',
+            elo: 0,
+            country: '',
+            fideId: 600000,
+          },
+          {
+            color: 1,
+            firstName: ' Master',
+            lastName: 'Yoda',
+            elo: 0,
+            country: '',
+            fideId: 1000000,
+          },
+        ],
+      },
+    },
+  ];
+
+  testCases.forEach(test => {
+    it(test.name, () => {
+      const result = chessEngine.parseGameInfo(test.pgn);
+      if (test.shouldFail) {
+        expect(isError(result)).toEqual(true);
+      } else {
+        expect(result).toEqual(succ(test.expectedResult));
+      }
+    });
+  });
 });
 
+// ---- chessEngine.startGame() ----
 test('testStartGame', () => {
-  const [board, startingFen] = startGame();
+  const [board, startingFen] = chessEngine.startGame();
   expect(startingFen).toStrictEqual(
     'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
   );
   expect(board.length).toStrictEqual(8);
   const countPeices = (
-    board: BoardPosition[][],
+    board: ChessBoardPositions,
     color: PlayerColour,
   ): number => {
     let count = 0;

--- a/packages/TorneloScoresheet/src/chessEngine/chessEngineInterface.ts
+++ b/packages/TorneloScoresheet/src/chessEngine/chessEngineInterface.ts
@@ -1,0 +1,26 @@
+import { ChessBoardPositions } from '../types/ChessBoardPositions';
+import { ChessGameInfo } from '../types/ChessGameInfo';
+import { Result } from '../types/Result';
+import { chessTsChessEngine } from './chessTsChessEngine';
+
+/**
+ * The interface for the chess engine wrapper, this type is used all
+ * over the code to interact with the chess engine
+ */
+export type ChessEngineInterface = {
+  /**
+   * Extracts game info from a pgn string (using headers) will return undefined if error occurs when parsing.
+   * @param pgn pgn string of the game to be parsed
+   * @returns All info of game from headers
+   */
+  parseGameInfo: (pgn: string) => Result<ChessGameInfo>;
+
+  /**
+   * Starts a new game and returns starting fen and board positions
+   * @returns [Board positions, starting fen]
+   */
+  startGame: () => [ChessBoardPositions, string];
+};
+
+// change the chess engine implementation here
+export const chessEngine: ChessEngineInterface = chessTsChessEngine;

--- a/packages/TorneloScoresheet/src/chessEngine/chessTsChessEngine.ts
+++ b/packages/TorneloScoresheet/src/chessEngine/chessTsChessEngine.ts
@@ -4,26 +4,28 @@ import {
   boardIndexToPosition,
   BoardPosition,
   ChessBoardPositions,
-} from './types/ChessBoardPositions';
+} from '../types/ChessBoardPositions';
 import {
   ChessGameInfo,
   Player,
   PlayerColour,
   PLAYER_COLOUR_NAME,
-} from './types/ChessGameInfo';
-import { Piece, PieceType } from './types/ChessMove';
-import { Result, succ, fail, isError } from './types/Result';
+} from '../types/ChessGameInfo';
+import { Piece, PieceType } from '../types/ChessMove';
+import { Result, succ, fail, isError } from '../types/Result';
+import { ChessEngineInterface } from './chessEngineInterface';
 
 const PARSING_FAILURE = fail(
   'Invalid PGN returned from website. Please double check the link',
 );
 
+// ------- Public interface
 /**
  * Extracts game info from a pgn string (using headers) will return undefined if error occurs when parsing.
  * @param pgn pgn string of the game to be parsed
  * @returns All info of game from headers
  */
-export const parseGameInfo = (pgn: string): Result<ChessGameInfo> => {
+const parseGameInfo = (pgn: string): Result<ChessGameInfo> => {
   // create game object to parse pgn
   let game = new Chess();
 
@@ -73,9 +75,17 @@ export const parseGameInfo = (pgn: string): Result<ChessGameInfo> => {
  * Starts a new game and returns starting fen and board positions
  * @returns [Board positions, starting fen]
  */
-export const startGame = (): [ChessBoardPositions, string] => {
+const startGame = (): [ChessBoardPositions, string] => {
   const game = new Chess();
   return [gameToPeiceArray(game), game.fen()];
+};
+
+/**
+ * The exported chess engine object which implements all the public methods
+ */
+export const chessTsChessEngine: ChessEngineInterface = {
+  parseGameInfo,
+  startGame,
 };
 
 // ------- Privates

--- a/packages/TorneloScoresheet/src/hooks/appMode/enterPgnState.ts
+++ b/packages/TorneloScoresheet/src/hooks/appMode/enterPgnState.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import React, { useContext } from 'react';
-import { parseGameInfo } from '../../chessEngine';
+import { chessEngine } from '../../chessEngine/chessEngineInterface';
 import { AppModeState, AppMode, EnterPgnMode } from '../../types/AppModeState';
 import { ChessGameInfo } from '../../types/ChessGameInfo';
 import { isError, Result, succ, Success, fail } from '../../types/Result';
@@ -37,7 +37,7 @@ const makegoToTablePairingSelection =
       );
     }
 
-    const pairingOrFailures = pairingPgns.map(parseGameInfo);
+    const pairingOrFailures = pairingPgns.map(chessEngine.parseGameInfo);
 
     const firstError = pairingOrFailures.find(isError);
 


### PR DESCRIPTION
Decoupled our chessEngine wrapper from all the places in the code where it is called.
So from now on, whenver we use the chessEngine, we call it from chessEngine variable, which is of type ChessEngineInterface.
This allows us to easily change the chess Engine implementation without changing the imports all over the code, simply change the object the chessEngine variable is pointing to
The chessEngine tests have also been updated in this PR

PS: unfortunately typescript doesnt support docstrings on types, so the nice formatted docstring hints won't show up when you call chessEngine from the code :( (we'll live)

in chessEngine.ts (our interface):

![image](https://user-images.githubusercontent.com/26475724/167288936-8063574c-0003-4b74-8186-cf5dcbedb2cb.png)


in chessTsChessEngine.ts (our chess.ts implementation of the interface):
![image](https://user-images.githubusercontent.com/26475724/167288649-8c92ee06-efcf-4d33-a47c-9363ffba41ce.png)
