### PR TITLE
Update Chess Engine behaviour

### DIFF
--- a/packages/TorneloScoresheet/__tests__/chessEngine.test.ts
+++ b/packages/TorneloScoresheet/__tests__/chessEngine.test.ts
@@ -279,6 +279,13 @@ test('testStartGame', () => {
   expect(countPeices(board, PlayerColour.Black)).toStrictEqual(16);
 });
 
+test('initialFen', () => {
+  const startingFen = chessEngine.initialFen();
+  expect(startingFen).toStrictEqual(
+    'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+  );
+});
+
 // ---- chessEngine.fenToBoardPositions() ----
 describe('fenToBoardPositions', () => {
   const testCases = [

--- a/packages/TorneloScoresheet/__tests__/chessEngine.test.ts
+++ b/packages/TorneloScoresheet/__tests__/chessEngine.test.ts
@@ -265,10 +265,7 @@ describe('parseGameInfo', () => {
 
 // ---- chessEngine.startGame() ----
 test('testStartGame', () => {
-  const [board, startingFen] = chessEngine.startGame();
-  expect(startingFen).toStrictEqual(
-    'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
-  );
+  const board = chessEngine.startGame();
   expect(board.length).toStrictEqual(8 * 8);
   const countPeices = (
     boardToCount: BoardPosition[],

--- a/packages/TorneloScoresheet/__tests__/useAppModeState.test.ts
+++ b/packages/TorneloScoresheet/__tests__/useAppModeState.test.ts
@@ -12,7 +12,7 @@ import {
   mockAppModeContext,
   renderCustomHook,
 } from '../src/testUtils';
-import { PlySquares } from '../src/types/ChessMove';
+import { ChessMove, PlySquares } from '../src/types/ChessMove';
 import { chessEngine } from '../src/chessEngine/chessEngineInterface';
 import axios, { AxiosRequestConfig } from 'axios';
 
@@ -99,21 +99,11 @@ describe('useAppModeState', () => {
 
 describe('graphical recording moving', () => {
   test('test white move in graphical recording mode', () => {
-    const originFen =
-      'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
-    const resultingFen =
+    const resultantFen =
       'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1';
     const move = { from: 'e2', to: 'e4' };
-    const moveHistory = [
-      {
-        moveNo: 1,
-        whitePly: {
-          startingFen: originFen,
-        },
-      },
-    ];
 
-    const graphicalState = generateGraphicalRecordingState(moveHistory);
+    const graphicalState = generateGraphicalRecordingState([]);
     const setContextMock = mockAppModeContext(graphicalState);
     const graphicalStateHook = renderCustomHook(useGraphicalRecordingState);
 
@@ -123,35 +113,31 @@ describe('graphical recording moving', () => {
       expect(setContextMock).toHaveBeenCalledTimes(1);
       expect(setContextMock).toHaveBeenCalledWith({
         ...graphicalState,
-        board: chessEngine.fenToBoardPositions(resultingFen),
+        board: chessEngine.fenToBoardPositions(resultantFen),
         moveHistory: [
           {
             moveNo: 1,
             whitePly: {
-              startingFen: originFen,
+              resultantFen,
               squares: move,
             },
-            blackPly: { startingFen: resultingFen },
           },
         ],
       });
     });
   });
   test('test black move in graphical recording mode', () => {
-    const originFen =
+    const originalFen =
       'rnbqkbnr/pppp2pp/8/4p3/4Pp2/2PP4/PP3PPP/RNBQKBNR b KQkq e3 0 1';
-    const resultingFen =
+    const resultantFen =
       'rnbqkbnr/pppp2pp/8/4p3/8/2PPp3/PP3PPP/RNBQKBNR w KQkq - 0 2';
     const move = { from: 'f4', to: 'e3' };
-    const moveHistory = [
+    const moveHistory: ChessMove[] = [
       {
         moveNo: 1,
         whitePly: {
-          startingFen: '',
+          resultantFen: originalFen,
           squares: { from: 'a1', to: 'a5' } as PlySquares,
-        },
-        blackPly: {
-          startingFen: originFen,
         },
       },
     ];
@@ -166,18 +152,14 @@ describe('graphical recording moving', () => {
       expect(setContextMock).toHaveBeenCalledTimes(1);
       expect(setContextMock).toHaveBeenCalledWith({
         ...graphicalState,
-        board: chessEngine.fenToBoardPositions(resultingFen),
+        board: chessEngine.fenToBoardPositions(resultantFen),
         moveHistory: [
           {
             ...moveHistory[0],
             blackPly: {
-              startingFen: originFen,
+              resultantFen,
               squares: move,
             },
-          },
-          {
-            moveNo: 2,
-            whitePly: { startingFen: resultingFen },
           },
         ],
       });

--- a/packages/TorneloScoresheet/src/chessEngine/chessEngineInterface.ts
+++ b/packages/TorneloScoresheet/src/chessEngine/chessEngineInterface.ts
@@ -20,7 +20,7 @@ export type ChessEngineInterface = {
    * Starts a new game and returns starting fen and board positions
    * @returns [Board positions, starting fen]
    */
-  startGame: () => [BoardPosition[], string];
+  startGame: () => BoardPosition[];
 
   /**
    * Processes a move given the starting fen and to and from positions

--- a/packages/TorneloScoresheet/src/chessEngine/chessEngineInterface.ts
+++ b/packages/TorneloScoresheet/src/chessEngine/chessEngineInterface.ts
@@ -36,6 +36,12 @@ export type ChessEngineInterface = {
    * @returns the board postions of the chess board
    */
   fenToBoardPositions: (fen: string) => BoardPosition[];
+
+  /**
+   * Return a fen string that represents the starting state of a
+   * game
+   */
+  initialFen: () => string;
 };
 
 // change the chess engine implementation here

--- a/packages/TorneloScoresheet/src/chessEngine/chessTsChessEngine.ts
+++ b/packages/TorneloScoresheet/src/chessEngine/chessTsChessEngine.ts
@@ -109,6 +109,14 @@ const makeMove = (
 };
 
 /**
+ * The initial board position of a chess game as a fen
+ *
+ * @returns the fen
+ */
+const initialFen = () =>
+  'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1';
+
+/**
  * The exported chess engine object which implements all the public methods
  */
 export const chessTsChessEngine: ChessEngineInterface = {
@@ -116,6 +124,7 @@ export const chessTsChessEngine: ChessEngineInterface = {
   startGame,
   makeMove,
   fenToBoardPositions,
+  initialFen,
 };
 
 // ------- Privates

--- a/packages/TorneloScoresheet/src/chessEngine/chessTsChessEngine.ts
+++ b/packages/TorneloScoresheet/src/chessEngine/chessTsChessEngine.ts
@@ -74,9 +74,9 @@ const parseGameInfo = (pgn: string): Result<ChessGameInfo> => {
  * Starts a new game and returns starting fen and board positions
  * @returns [Board positions, starting fen]
  */
-const startGame = (): [BoardPosition[], string] => {
+const startGame = (): BoardPosition[] => {
   const game = new Chess();
-  return [gameToPeiceArray(game), game.fen()];
+  return gameToPeiceArray(game);
 };
 
 /**

--- a/packages/TorneloScoresheet/src/hooks/appMode/graphicalRecordingState.ts
+++ b/packages/TorneloScoresheet/src/hooks/appMode/graphicalRecordingState.ts
@@ -6,7 +6,8 @@ import {
   GraphicalRecordingMode,
 } from '../../types/AppModeState';
 import { BoardPosition } from '../../types/ChessBoardPositions';
-import { ChessMove, ChessPly, PlySquares } from '../../types/ChessMove';
+import { ChessMove, PlySquares } from '../../types/ChessMove';
+import { replaceLastElement } from '../../util/array';
 
 type GraphicalRecordingStateHookType = [
   GraphicalRecordingMode,
@@ -19,99 +20,85 @@ type GraphicalRecordingStateHookType = [
 ];
 
 /**
- * Process Ply based on the from and to positions
- * Returns the next Ply with it's starting fen
- * Returns null if move was impossible
- * @param currentPly the Ply that should be processed
- * @returns next ply if move is successfull else null
- */
-const processPly = (currentPly: ChessPly): ChessPly | null => {
-  if (currentPly.squares === undefined) {
-    return null;
-  }
-  const nextFen = chessEngine.makeMove(
-    currentPly.startingFen,
-    currentPly.squares,
-  );
-
-  // if move was not possible, return null
-  if (nextFen === null) {
-    return null;
-  }
-
-  return { startingFen: nextFen };
-};
-
-/**
- * Adds the next ply to the move history
- * If White's turn, sets blackPly as next ply
- * If Black's turn, set whitePly as next ply in a new move
- * @param moveHistory the list of all past moves
- * @param currentMove the current chess move
- * @param nextPly the next ply to add to move history
- * @returns the next move history including the next ply
- */
-const addNextPlyToMoveHistory = (
-  moveHistory: ChessMove[],
-  currentMove: ChessMove,
-  currentPly: ChessPly,
-  nextPly: ChessPly,
-): ChessMove[] => {
-  // White's move
-  if (currentMove.blackPly === undefined) {
-    return [
-      ...moveHistory.slice(0, -1),
-      { ...currentMove, whitePly: currentPly, blackPly: nextPly },
-    ];
-  }
-
-  // Black's move
-  else {
-    const nextMove = {
-      moveNo: currentMove.moveNo + 1,
-      whitePly: nextPly,
-    };
-    return [
-      ...moveHistory.slice(0, -1),
-      { ...currentMove, blackPly: currentPly },
-      nextMove,
-    ];
-  }
-};
-
-/**
- * Processes a player's move given to and from positons
+ * Processes a player's move given to and from positons and the
+ * current history of the game
+ *
  * Will Return the next board state and the move history array
  * Will return null if move is impossible
- * @param fromPos postion piece starts from
- * @param toPos postion piece goes to
- * @param appModeState the GraphicalRecordingMode state
- * @param setAppModeStateAfterMove the state update function
- * @returns [boardPositions, moveHistory] or null
+ * @param {PlySquares} plySquares
+ * @param {ChessMove[]} moveHistory
  */
 const processPlayerMove = (
   plySquares: PlySquares,
   moveHistory: ChessMove[],
-): [BoardPosition[], ChessMove[]] | null => {
-  const currentMove = moveHistory[moveHistory.length - 1];
-  const currentPly = {
-    ...(currentMove.blackPly === undefined
-      ? currentMove.whitePly
-      : currentMove.blackPly),
-    squares: plySquares,
-  };
+): { newPosition: BoardPosition[]; newHistory: ChessMove[] } | null => {
+  // This is the first move of the game so let's shortcircuit
+  if (!moveHistory.length) {
+    const resultantFen = chessEngine.makeMove(
+      chessEngine.initialFen(),
+      plySquares,
+    );
+    if (!resultantFen) {
+      return null;
+    }
 
-  // process ply, return null if not possible
-  const nextPly = processPly(currentPly);
-  if (nextPly === null) {
+    return {
+      newPosition: chessEngine.fenToBoardPositions(resultantFen),
+      newHistory: [
+        {
+          moveNo: 1,
+          whitePly: {
+            squares: plySquares,
+            resultantFen,
+          },
+        },
+      ],
+    };
+  }
+
+  // Now that we know a move has been made, we can fetch it from
+  // the history
+  const mostRecentMove = moveHistory[moveHistory.length - 1];
+  const isBlacksMove = mostRecentMove.blackPly === undefined;
+
+  const previousPly = isBlacksMove
+    ? mostRecentMove.whitePly
+    : mostRecentMove.blackPly;
+
+  if (!previousPly?.squares) {
     return null;
   }
 
-  // return new state
-  return [
-    chessEngine.fenToBoardPositions(nextPly.startingFen),
-    addNextPlyToMoveHistory(moveHistory, currentMove, currentPly, nextPly),
-  ];
+  const resultantFen = chessEngine.makeMove(
+    previousPly.resultantFen,
+    plySquares,
+  );
+
+  if (!resultantFen) {
+    return null;
+  }
+
+  // Need to replace the move in the end of the history
+  return {
+    newPosition: chessEngine.fenToBoardPositions(resultantFen),
+    newHistory: isBlacksMove
+      ? replaceLastElement(moveHistory, {
+          ...mostRecentMove,
+          blackPly: {
+            squares: plySquares,
+            resultantFen,
+          },
+        })
+      : moveHistory.concat([
+          {
+            moveNo: mostRecentMove.moveNo + 1,
+            whitePly: {
+              squares: plySquares,
+              resultantFen,
+            },
+          },
+        ]),
+  };
 };
 
 export const makeUseGraphicalRecordingState =
@@ -133,12 +120,11 @@ export const makeUseGraphicalRecordingState =
     const moveFunc = (plySquares: PlySquares): void => {
       const result = processPlayerMove(plySquares, appModeState.moveHistory);
       if (result !== null) {
-        const [board, moveHistory] = result;
-        console.log(moveHistory);
+        const { newPosition, newHistory } = result;
         setAppModeState({
           ...appModeState,
-          board,
-          moveHistory,
+          board: newPosition,
+          moveHistory: newHistory,
         });
       }
     };

--- a/packages/TorneloScoresheet/src/hooks/appMode/tablePairingState.ts
+++ b/packages/TorneloScoresheet/src/hooks/appMode/tablePairingState.ts
@@ -27,12 +27,11 @@ export const makeUseTablePairingState =
     }
 
     const goToRecording = (currentPlayer: PlayerColour): void => {
-      var [board, fen] = chessEngine.startGame();
       setAppModeState({
         mode: AppMode.GraphicalRecording,
         pairing: appModeState.pairing,
-        moveHistory: [{ moveNo: 1, whitePly: { startingFen: fen } }],
-        board,
+        moveHistory: [],
+        board: chessEngine.startGame(),
         currentPlayer,
       });
     };

--- a/packages/TorneloScoresheet/src/types/ChessMove.ts
+++ b/packages/TorneloScoresheet/src/types/ChessMove.ts
@@ -16,8 +16,8 @@ export type Piece = {
 };
 
 export type ChessPly = {
-  squares?: PlySquares;
-  startingFen: string;
+  squares: PlySquares;
+  resultantFen: string;
 };
 
 export type PlySquares = {

--- a/packages/TorneloScoresheet/src/util/array.ts
+++ b/packages/TorneloScoresheet/src/util/array.ts
@@ -1,0 +1,8 @@
+/**
+ * Givan array, return a new array with the last
+ * element replaced with the given element
+ *
+ * (we don't modify the given array)
+ */
+export const replaceLastElement = <T>(arr: T[], newEl: T) =>
+  arr.map((el, i) => (arr.length - 1 === i ? newEl : el));


### PR DESCRIPTION
Specifically, updated the behaviour of the `move` function. Please see the commit messages for details, but this patch basically makes the behaviour less unexpected, and removes the requirement for having a "dummy" move in the history at the start of a game. :^)