### PR TITLE
Refractor move history

### DIFF
--- a/packages/TorneloScoresheet/__tests__/chessEngine.test.ts
+++ b/packages/TorneloScoresheet/__tests__/chessEngine.test.ts
@@ -2,7 +2,7 @@ import moment from 'moment';
 import { chessEngine } from '../src/chessEngine/chessEngineInterface';
 import { BoardPosition, Position } from '../src/types/ChessBoardPositions';
 import { PlayerColour } from '../src/types/ChessGameInfo';
-import { Piece, PieceType, PlySquares } from '../src/types/ChessMove';
+import { Piece, PieceType, MoveSquares } from '../src/types/ChessMove';
 import { isError, succ } from '../src/types/Result';
 
 // ---- chessEngine.parseGameInfo() ----
@@ -265,21 +265,10 @@ describe('parseGameInfo', () => {
 
 // ---- chessEngine.startGame() ----
 test('testStartGame', () => {
-  const [board, startingFen] = chessEngine.startGame();
+  const startingFen = chessEngine.startingFen();
   expect(startingFen).toStrictEqual(
     'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
   );
-  expect(board.length).toStrictEqual(8 * 8);
-  const countPeices = (
-    boardToCount: BoardPosition[],
-    color: PlayerColour,
-  ): number => {
-    return boardToCount.filter(
-      position => position.piece !== null && position.piece.player === color,
-    ).length;
-  };
-  expect(countPeices(board, PlayerColour.White)).toStrictEqual(16);
-  expect(countPeices(board, PlayerColour.Black)).toStrictEqual(16);
 });
 
 // ---- chessEngine.fenToBoardPositions() ----
@@ -914,7 +903,7 @@ describe('makeMove', () => {
   ];
   const boardCorrect = (
     board: BoardPosition[],
-    pliePosition: PlySquares,
+    pliePosition: MoveSquares,
     piece: Piece,
   ): boolean => {
     const fromSquare = board.find(

--- a/packages/TorneloScoresheet/__tests__/useAppModeState.test.ts
+++ b/packages/TorneloScoresheet/__tests__/useAppModeState.test.ts
@@ -12,9 +12,10 @@ import {
   mockAppModeContext,
   renderCustomHook,
 } from '../src/testUtils';
-import { PlySquares } from '../src/types/ChessMove';
+import { MoveSquares } from '../src/types/ChessMove';
 import { chessEngine } from '../src/chessEngine/chessEngineInterface';
 import axios, { AxiosRequestConfig } from 'axios';
+import { PlayerColour } from '../src/types/ChessGameInfo';
 
 describe('useAppModeState', () => {
   test('initial state', () => {
@@ -104,21 +105,13 @@ describe('graphical recording moving', () => {
     const resultingFen =
       'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq e3 0 1';
     const move = { from: 'e2', to: 'e4' };
-    const moveHistory = [
-      {
-        moveNo: 1,
-        whitePly: {
-          startingFen: originFen,
-        },
-      },
-    ];
 
-    const graphicalState = generateGraphicalRecordingState(moveHistory);
+    const graphicalState = generateGraphicalRecordingState([]);
     const setContextMock = mockAppModeContext(graphicalState);
     const graphicalStateHook = renderCustomHook(useGraphicalRecordingState);
 
     act(() => {
-      graphicalStateHook.current?.[1].move(move as PlySquares);
+      graphicalStateHook.current?.[1].move(move as MoveSquares);
 
       expect(setContextMock).toHaveBeenCalledTimes(1);
       expect(setContextMock).toHaveBeenCalledWith({
@@ -127,11 +120,9 @@ describe('graphical recording moving', () => {
         moveHistory: [
           {
             moveNo: 1,
-            whitePly: {
-              startingFen: originFen,
-              squares: move,
-            },
-            blackPly: { startingFen: resultingFen },
+            startingFen: originFen,
+            move,
+            player: PlayerColour.White,
           },
         ],
       });
@@ -139,20 +130,16 @@ describe('graphical recording moving', () => {
   });
   test('test black move in graphical recording mode', () => {
     const originFen =
-      'rnbqkbnr/pppp2pp/8/4p3/4Pp2/2PP4/PP3PPP/RNBQKBNR b KQkq e3 0 1';
+      'rnbqkbnr/pppppppp/8/R7/8/8/PPPPPPPP/1NBQKBNR b Kkq - 1 1';
     const resultingFen =
-      'rnbqkbnr/pppp2pp/8/4p3/8/2PPp3/PP3PPP/RNBQKBNR w KQkq - 0 2';
-    const move = { from: 'f4', to: 'e3' };
+      'rnbqkbn1/pppppppp/8/R6r/8/8/PPPPPPPP/1NBQKBNR w Kq - 0 1';
+    const move = { from: 'h8', to: 'h5' };
     const moveHistory = [
       {
         moveNo: 1,
-        whitePly: {
-          startingFen: '',
-          squares: { from: 'a1', to: 'a5' } as PlySquares,
-        },
-        blackPly: {
-          startingFen: originFen,
-        },
+        player: PlayerColour.White,
+        startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+        move: { from: 'a1', to: 'a5' } as MoveSquares,
       },
     ];
 
@@ -161,7 +148,7 @@ describe('graphical recording moving', () => {
     const graphicalStateHook = renderCustomHook(useGraphicalRecordingState);
 
     act(() => {
-      graphicalStateHook.current?.[1].move(move as PlySquares);
+      graphicalStateHook.current?.[1].move(move as MoveSquares);
 
       expect(setContextMock).toHaveBeenCalledTimes(1);
       expect(setContextMock).toHaveBeenCalledWith({
@@ -169,15 +156,17 @@ describe('graphical recording moving', () => {
         board: chessEngine.fenToBoardPositions(resultingFen),
         moveHistory: [
           {
-            ...moveHistory[0],
-            blackPly: {
-              startingFen: originFen,
-              squares: move,
-            },
+            moveNo: 1,
+            player: PlayerColour.White,
+            startingFen:
+              'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+            move: { from: 'a1', to: 'a5' } as MoveSquares,
           },
           {
-            moveNo: 2,
-            whitePly: { startingFen: resultingFen },
+            moveNo: 1,
+            player: PlayerColour.Black,
+            startingFen: originFen,
+            move,
           },
         ],
       });

--- a/packages/TorneloScoresheet/src/chessEngine/chessEngineInterface.ts
+++ b/packages/TorneloScoresheet/src/chessEngine/chessEngineInterface.ts
@@ -1,6 +1,6 @@
 import { BoardPosition } from '../types/ChessBoardPositions';
 import { ChessGameInfo } from '../types/ChessGameInfo';
-import { PlySquares } from '../types/ChessMove';
+import { MoveSquares } from '../types/ChessMove';
 import { Result } from '../types/Result';
 import { chessTsChessEngine } from './chessTsChessEngine';
 
@@ -17,18 +17,18 @@ export type ChessEngineInterface = {
   parseGameInfo: (pgn: string) => Result<ChessGameInfo>;
 
   /**
-   * Starts a new game and returns starting fen and board positions
-   * @returns [Board positions, starting fen]
+   * returns starting fen of a chess game
+   * @returns starting fen
    */
-  startGame: () => [BoardPosition[], string];
+  startingFen: () => string;
 
   /**
    * Processes a move given the starting fen and to and from positions
    * @param startingFen the fen of the game state before the move
-   * @param plySquares the to and from positions of the move
+   * @param moveSquares the to and from positions of the move
    * @returns the next fen if move is possible else null
    */
-  makeMove: (startingFen: string, plySquares: PlySquares) => string | null;
+  makeMove: (startingFen: string, moveSquares: MoveSquares) => string | null;
 
   /**
    * Returns the board postion state given a fen

--- a/packages/TorneloScoresheet/src/chessEngine/chessTsChessEngine.ts
+++ b/packages/TorneloScoresheet/src/chessEngine/chessTsChessEngine.ts
@@ -10,7 +10,7 @@ import {
   PlayerColour,
   PLAYER_COLOUR_NAME,
 } from '../types/ChessGameInfo';
-import { Piece, PieceType, PlySquares } from '../types/ChessMove';
+import { Piece, PieceType, MoveSquares } from '../types/ChessMove';
 import { Result, succ, fail, isError } from '../types/Result';
 import { ChessEngineInterface } from './chessEngineInterface';
 
@@ -71,12 +71,12 @@ const parseGameInfo = (pgn: string): Result<ChessGameInfo> => {
 };
 
 /**
- * Starts a new game and returns starting fen and board positions
- * @returns [Board positions, starting fen]
+ * returns starting fen of a chess game
+ * @returns starting fen
  */
-const startGame = (): [BoardPosition[], string] => {
+const startingFen = (): string => {
   const game = new Chess();
-  return [gameToPeiceArray(game), game.fen()];
+  return game.fen();
 };
 
 /**
@@ -92,15 +92,18 @@ const fenToBoardPositions = (fen: string): BoardPosition[] => {
 /**
  * Processes a move given the starting fen and to and from positions
  * @param startingFen the fen of the game state before the move
- * @param plie the to and from positions of the move
+ * @param moveSquares the to and from positions of the move
  * @returns the next fen if move is possible else null
  */
 const makeMove = (
   startingFen: string,
-  plySquares: PlySquares,
+  moveSquares: MoveSquares,
 ): string | null => {
   const game = new Chess(startingFen);
-  const result = game.forceMove({ from: plySquares.from, to: plySquares.to });
+  const result = game.forceMove({
+    from: moveSquares.from,
+    to: moveSquares.to,
+  });
   if (result === null) {
     return null;
   }
@@ -113,7 +116,7 @@ const makeMove = (
  */
 export const chessTsChessEngine: ChessEngineInterface = {
   parseGameInfo,
-  startGame,
+  startingFen,
   makeMove,
   fenToBoardPositions,
 };

--- a/packages/TorneloScoresheet/src/components/ChessBoard/ChessBoard.tsx
+++ b/packages/TorneloScoresheet/src/components/ChessBoard/ChessBoard.tsx
@@ -5,7 +5,7 @@ import {
   boardPositionToIndex,
   Position,
 } from '../../types/ChessBoardPositions';
-import { PlySquares } from '../../types/ChessMove';
+import { MoveSquares } from '../../types/ChessMove';
 import { CHESS_SQUARE_SIZE } from '../ChessSquare/ChessSquare';
 import DragAndDropContextProvider from '../DragAndDrop/DragAndDropContext/DragAndDropContext';
 import Draggable from '../DragAndDrop/Draggable/Draggable';
@@ -17,7 +17,7 @@ import { styles } from './style';
 export type ChessBoardProps = {
   positions: BoardPosition[];
   flipBoard?: boolean;
-  onMove: (plySquares: PlySquares) => void;
+  onMove: (moveSquares: MoveSquares) => void;
 };
 
 const squareColour = (position: Position) => {

--- a/packages/TorneloScoresheet/src/hooks/appMode/tablePairingState.ts
+++ b/packages/TorneloScoresheet/src/hooks/appMode/tablePairingState.ts
@@ -27,11 +27,11 @@ export const makeUseTablePairingState =
     }
 
     const goToRecording = (currentPlayer: PlayerColour): void => {
-      var [board, fen] = chessEngine.startGame();
+      const board = chessEngine.fenToBoardPositions(chessEngine.startingFen());
       setAppModeState({
         mode: AppMode.GraphicalRecording,
         pairing: appModeState.pairing,
-        moveHistory: [{ moveNo: 1, whitePly: { startingFen: fen } }],
+        moveHistory: [],
         board,
         currentPlayer,
       });

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
@@ -17,7 +17,7 @@ import {
   ICON_UNDO,
 } from '../../style/images';
 import { PlayerColour } from '../../types/ChessGameInfo';
-import { PlySquares } from '../../types/ChessMove';
+import { MoveSquares } from '../../types/ChessMove';
 import { styles } from './style';
 
 const GraphicalRecording: React.FC = () => {
@@ -81,7 +81,7 @@ const GraphicalRecording: React.FC = () => {
     },
   ];
 
-  const onMove = (plySquares: PlySquares) => {
+  const onMove = (plySquares: MoveSquares) => {
     if (!move) {
       return;
     }

--- a/packages/TorneloScoresheet/src/testUtils.ts
+++ b/packages/TorneloScoresheet/src/testUtils.ts
@@ -9,7 +9,7 @@ import {
   GraphicalRecordingMode,
 } from './types/AppModeState';
 import { ChessGameInfo, PlayerColour } from './types/ChessGameInfo';
-import { ChessMove } from './types/ChessMove';
+import { ChessPly } from './types/ChessMove';
 
 /**
  * Mocks a hook for testing
@@ -62,7 +62,7 @@ export const generateGamePairingInfo = (): ChessGameInfo => {
  * @returns Graphical recording state object
  */
 export const generateGraphicalRecordingState = (
-  moveHistory: ChessMove[],
+  moveHistory: ChessPly[],
 ): GraphicalRecordingMode => {
   return {
     mode: AppMode.GraphicalRecording,

--- a/packages/TorneloScoresheet/src/types/AppModeState.ts
+++ b/packages/TorneloScoresheet/src/types/AppModeState.ts
@@ -1,6 +1,6 @@
 import { BoardPosition } from './ChessBoardPositions';
 import { ChessGameInfo, PlayerColour } from './ChessGameInfo';
-import { ChessMove } from './ChessMove';
+import { ChessPly } from './ChessMove';
 
 export enum AppMode {
   EnterPgn,
@@ -27,7 +27,7 @@ export type TablePairingMode = {
 export type GraphicalRecordingMode = {
   mode: AppMode.GraphicalRecording;
   pairing: ChessGameInfo;
-  moveHistory: ChessMove[];
+  moveHistory: ChessPly[];
   board: BoardPosition[];
   currentPlayer: PlayerColour;
 };

--- a/packages/TorneloScoresheet/src/types/ChessMove.ts
+++ b/packages/TorneloScoresheet/src/types/ChessMove.ts
@@ -15,18 +15,14 @@ export type Piece = {
   player: PlayerColour;
 };
 
-export type ChessPly = {
-  squares?: PlySquares;
-  startingFen: string;
-};
-
-export type PlySquares = {
+export type MoveSquares = {
   from: Position;
   to: Position;
 };
 
-export type ChessMove = {
-  whitePly: ChessPly;
-  blackPly?: ChessPly;
+export type ChessPly = {
   moveNo: number;
+  startingFen: string;
+  player: PlayerColour;
+  move: MoveSquares;
 };


### PR DESCRIPTION
Change how we store our history,
Instead of storing it in a `ChessMove` array which has whitePly and blackPly, 
We store just the plys directly in an array
This is much much cleaner as we don't have to do the checks for whos turn it is
This will also make it so much easier to undo and skip moves 