### PR TITLE
Auto skip turn

### DIFF
--- a/packages/TorneloScoresheet/__tests__/chessEngine.test.ts
+++ b/packages/TorneloScoresheet/__tests__/chessEngine.test.ts
@@ -1050,3 +1050,45 @@ describe('Skip Turn', () => {
     });
   });
 });
+
+// ---- chessEngine.isOtherPlayersPiece() ----
+describe("is other player's piece", () => {
+  const testCases = [
+    {
+      name: 'White turn own piece',
+      startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+      move: { from: 'e2', to: 'e4' },
+      isOtherPlayersPiece: false,
+    },
+    {
+      name: "White turn Black's piece",
+      startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+      move: { from: 'e8', to: 'e5' },
+      isOtherPlayersPiece: true,
+    },
+    {
+      name: 'Black turn own piece',
+      startingFen:
+        'rnbqkbnr/pppp2pp/8/4p3/4Pp2/2PP4/PP3PPP/RNBQKBNR b KQkq e3 0 1',
+      move: { from: 'f4', to: 'e3' },
+      isOtherPlayersPiece: false,
+    },
+    {
+      name: "Black turn white's piece",
+      startingFen:
+        'rnbqkbnr/pppp2pp/8/4p3/4Pp2/2PP4/PP3PPP/RNBQKBNR b KQkq e3 0 1',
+      move: { from: 'a1', to: 'a5' },
+      isOtherPlayersPiece: true,
+    },
+  ];
+
+  testCases.forEach(testCase => {
+    it(testCase.name, () => {
+      const result = chessEngine.isOtherPlayersPiece(
+        testCase.startingFen,
+        testCase.move as MoveSquares,
+      );
+      expect(result).toStrictEqual(testCase.isOtherPlayersPiece);
+    });
+  });
+});

--- a/packages/TorneloScoresheet/src/chessEngine/chessEngineInterface.ts
+++ b/packages/TorneloScoresheet/src/chessEngine/chessEngineInterface.ts
@@ -57,6 +57,16 @@ export type ChessEngineInterface = {
    * @returns the fen as the next player's turn
    */
   skipTurn: (fen: string) => string;
+
+  /**
+   * Determins if the move is attempting to move the opposite player's piece
+   * This can be used to determine if the player is intending to auto skip a turn
+   *
+   * @param fen the current state of the board
+   * @param moveSquares the to and from positions of the move
+   * @returns if the move is targeting the opposite player's piece
+   */
+  isOtherPlayersPiece: (fen: string, move: MoveSquares) => boolean;
 };
 
 // change the chess engine implementation here

--- a/packages/TorneloScoresheet/src/chessEngine/chessTsChessEngine.ts
+++ b/packages/TorneloScoresheet/src/chessEngine/chessTsChessEngine.ts
@@ -145,6 +145,19 @@ const skipTurn = (fen: string): string => {
 };
 
 /**
+ * Determins if the move is attempting to move the opposite player's piece
+ * This can be used to determine if the player is intending to auto skip a turn
+ *
+ * @param fen the current state of the board
+ * @param moveSquares the to and from positions of the move
+ * @returns if the move is targeting the opposite player's piece
+ */
+const isOtherPlayersPiece = (fen: string, move: MoveSquares): boolean => {
+  const game = new Chess(fen);
+  return game.isOtherPlayersPiece(move);
+};
+
+/**
  * The exported chess engine object which implements all the public methods
  */
 export const chessTsChessEngine: ChessEngineInterface = {
@@ -154,6 +167,7 @@ export const chessTsChessEngine: ChessEngineInterface = {
   fenToBoardPositions,
   isPawnPromotion,
   skipTurn,
+  isOtherPlayersPiece,
 };
 
 // ------- Privates

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
@@ -34,6 +34,9 @@ const GraphicalRecording: React.FC = () => {
   const undoLastMove = graphicalRecordingState?.[1].undoLastMove;
   const isPawnPromotion = graphicalRecordingState?.[1].isPawnPromotion;
   const skipTurn = graphicalRecordingState?.[1].skipTurn;
+  const isOtherPlayersPiece = graphicalRecordingState?.[1].isOtherPlayersPiece;
+  const skipTurnAndProcessMove =
+    graphicalRecordingState?.[1].skipTurnAndProcessMove;
 
   // states
   const [flipBoard, setFlipBoard] = useState(
@@ -150,20 +153,26 @@ const GraphicalRecording: React.FC = () => {
   };
 
   const onMove = async (moveSquares: MoveSquares): Promise<void> => {
-    if (!move || !isPawnPromotion) {
+    if (
+      !move ||
+      !isPawnPromotion ||
+      !isOtherPlayersPiece ||
+      !skipTurnAndProcessMove
+    ) {
       return;
     }
 
+    // check for promotion
+    let promotion: PieceType | undefined;
     if (isPawnPromotion(moveSquares)) {
       // prompt user to select piece and wait until they do
-      const selectedPromotion = await promptUserForPromotionChoice();
-      move(moveSquares, selectedPromotion);
-
-      return;
+      promotion = await promptUserForPromotionChoice();
     }
 
-    // no pawn promotion -> normal move
-    move(moveSquares);
+    // auto skip turn + move or regular move
+    isOtherPlayersPiece(moveSquares)
+      ? skipTurnAndProcessMove(moveSquares, promotion)
+      : move(moveSquares, promotion);
   };
 
   return (

--- a/packages/chess.ts/__tests__/chess.test.ts
+++ b/packages/chess.ts/__tests__/chess.test.ts
@@ -3256,3 +3256,42 @@ describe('Skip Turn', () => {
     })
   })
 })
+
+describe("is other player's piece", () => {
+  const testCases = [
+    {
+      name: 'White turn own piece',
+      startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+      move: { from: 'e2', to: 'e4' },
+      isOtherPlayersPiece: false,
+    },
+    {
+      name: "White turn Black's piece",
+      startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+      move: { from: 'e8', to: 'e5' },
+      isOtherPlayersPiece: true,
+    },
+    {
+      name: 'Black turn own piece',
+      startingFen:
+        'rnbqkbnr/pppp2pp/8/4p3/4Pp2/2PP4/PP3PPP/RNBQKBNR b KQkq e3 0 1',
+      move: { from: 'f4', to: 'e3' },
+      isOtherPlayersPiece: false,
+    },
+    {
+      name: "Black turn white's piece",
+      startingFen:
+        'rnbqkbnr/pppp2pp/8/4p3/4Pp2/2PP4/PP3PPP/RNBQKBNR b KQkq e3 0 1',
+      move: { from: 'a1', to: 'a5' },
+      isOtherPlayersPiece: true,
+    },
+  ]
+
+  testCases.forEach((testCase) => {
+    it(testCase.name, () => {
+      const game = new Chess(testCase.startingFen)
+      const result = game.isOtherPlayersPiece(testCase.move)
+      expect(result).toStrictEqual(testCase.isOtherPlayersPiece)
+    })
+  })
+})

--- a/packages/chess.ts/__tests__/chess.test.ts
+++ b/packages/chess.ts/__tests__/chess.test.ts
@@ -489,6 +489,13 @@ describe('isPromotionAllowIllegal', function () {
       move: { from: 'g7', to: 'g8' },
       promotion: false,
     },
+    // legal promotion - checking as white when black's turn
+    {
+      fen: '8/2P2k2/8/8/8/5K2/8/8 b - - 0 1',
+      san: 'c8',
+      move: { from: 'c7', to: 'c8' },
+      promotion: true,
+    },
   ]
 
   positions.forEach(function (position) {

--- a/packages/chess.ts/src/chess.ts
+++ b/packages/chess.ts/src/chess.ts
@@ -944,12 +944,7 @@ export class Chess {
    * @param move - object, e.g.  `{ from: 'h7', to: 'h8' }`
    */
   public isPromotionAllowIllegal(move: PartialMove): boolean {
-    return pawnPromotionAllowIllegal(
-      this._state.board,
-      move.from,
-      move.to,
-      this._state.turn
-    )
+    return pawnPromotionAllowIllegal(this._state.board, move.from, move.to)
   }
 
   /**

--- a/packages/chess.ts/src/chess.ts
+++ b/packages/chess.ts/src/chess.ts
@@ -20,6 +20,7 @@ import {
   pawnPromotionAllowIllegal,
   processMove,
   skipTurn,
+  isOtherPlayersPiece,
 } from './state'
 import {
   Color,
@@ -1258,6 +1259,16 @@ export class Chess {
    */
   public skipTurn(): void {
     this._state = skipTurn(this._state)
+  }
+
+  /**
+   * Will determin if the current move is trying to move the other player's piece
+   * This can be used to determin if the player intends to skip a turn automatically
+   * @param move the move inputed
+   * @returns whether the move is targeting the opposite player's piece
+   */
+  public isOtherPlayersPiece(move: PartialMove): boolean {
+    return isOtherPlayersPiece(this._state, move)
   }
 
   /**

--- a/packages/chess.ts/src/state.ts
+++ b/packages/chess.ts/src/state.ts
@@ -1213,6 +1213,24 @@ export function skipTurn(state: State): State {
   return state
 }
 
+export function isOtherPlayersPiece(state: State, move: PartialMove): boolean {
+  const us = state.turn
+
+  // check if squares exists
+  let from = move.from.toLowerCase()
+  if (!isSquare(from)) {
+    return false
+  }
+  const fromSquare = SQUARES[from]
+
+  // check from square is our peice
+  const piece = state.board[fromSquare]
+  if (piece && piece.color !== us) {
+    return true
+  }
+  return false
+}
+
 export function buildMove(
   state: State,
   from: number,

--- a/packages/chess.ts/src/state.ts
+++ b/packages/chess.ts/src/state.ts
@@ -655,8 +655,7 @@ export function removePiece(prevState: State, square?: string): State | null {
 export function pawnPromotionAllowIllegal(
   board: Board,
   from: string,
-  to: string,
-  player: Color
+  to: string
 ): boolean {
   if (!isSquare(from) || !isSquare(to)) {
     return false
@@ -665,15 +664,13 @@ export function pawnPromotionAllowIllegal(
   const toSquare = SQUARES[to]
 
   const piece = board[fromSquare]
-  if (
-    piece &&
+  return (
+    piece !== undefined &&
     piece.type === PAWN &&
-    ((player === 'w' && rank(toSquare) === RANK_8) ||
-      (player === 'b' && rank(toSquare) === RANK_1))
-  ) {
-    return true
-  }
-  return false
+    (piece.color === WHITE
+      ? rank(toSquare) === RANK_8
+      : rank(toSquare) === RANK_1)
+  )
 }
 
 export function generateMoves(


### PR DESCRIPTION
When a player moves their piece twice in a row,
It is assumed that they intended to skip the other player's turn and register another move

This is acheived by the `isOtherPlayersPiece()` function in the chess.ts engine.
This function detects if the user is selecting a piece from the opposite color of the current turn.

When a player moves a piece the flow is as follows:
- Check if the move is a pawn promotion
- If promotion -> prompt user for promotion choice
- Determine if the piece moved is the wrong color (ie player is attempting to auto skip)
- If auto skip -> record `SkipPly` for current player and a `MovePly` with the desired move
- If not auto skip -> record a `MovePly` with the desired move for the current player

Demo: (Notice how when I undo, i have to press undo twice for moves that were skip since we are also undoing the `SkipPly`.

https://user-images.githubusercontent.com/26475724/173999250-2242fa4f-473b-4f97-9316-244040d88d19.mp4


