### PR TITLE
Added a first iteration of the `MoveCard` component

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 A Chess Scoresheet App for iOS.
 
-
 ## Development:
 
 It is strongly recommended to setup `pre-commit` when setting up a new environment: see `SETUP.md`.
@@ -18,6 +17,7 @@ It is strongly recommended to setup `pre-commit` when setting up a new environme
 ### Build app dependancies
 
 > go to TorneloScoresheet directory
+
 - `npm link ..\chess.ts`
 - `npm install`
 
@@ -37,3 +37,17 @@ It is strongly recommended to setup `pre-commit` when setting up a new environme
 > go to TorneloScoresheet directory
 
 - `npm run android`
+
+## Testing:
+
+To test the `chess.ts` package:
+
+- `cd packages/chess.ts`
+- `npm i`
+- `npm run test`
+
+To test the `TorneloScoresheet` package:
+
+- `cd packages/TorneloScoresheet`
+- `npm i`
+- `npm run test`

--- a/packages/TorneloScoresheet/src/components/MoveCard/MoveCard.tsx
+++ b/packages/TorneloScoresheet/src/components/MoveCard/MoveCard.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { View } from 'react-native';
+import { colours } from '../../style/colour';
+import { ChessPly, Move, PlyTypes } from '../../types/ChessMove';
+import PrimaryText, { Align, FontWeight } from '../PrimaryText/PrimaryText';
+import { styles } from './style';
+
+type MoveCardProps = {
+  move: Move;
+};
+
+const MoveCard: React.FC<MoveCardProps> = ({ move }) => {
+  return (
+    <View style={styles.container}>
+      <View style={styles.moveNumberContainer}>
+        <PrimaryText size={20} align={Align.Center} weight={FontWeight.Bold}>
+          # {move.white.moveNo}
+        </PrimaryText>
+      </View>
+      <View style={styles.whitePlyContainer}>
+        <PrimaryText size={20} align={Align.Center} weight={FontWeight.Bold}>
+          {moveString(move.white)}
+        </PrimaryText>
+      </View>
+      <View
+        style={[
+          styles.blackPlyContainer,
+          blackPlyBackgroundColour(move.black),
+        ]}>
+        {move.black && (
+          <PrimaryText size={20} align={Align.Center} weight={FontWeight.Bold}>
+            {moveString(move.black)}
+          </PrimaryText>
+        )}
+      </View>
+    </View>
+  );
+};
+
+const moveString = (ply: ChessPly): string => {
+  if (ply.type === PlyTypes.SkipPly) {
+    return '-';
+  }
+
+  return `${ply.move.from}->${ply.move.to}`;
+};
+
+const blackPlyBackgroundColour = (ply: ChessPly | undefined) => ({
+  backgroundColor: ply ? colours.darkBlue : colours.tertiary,
+});
+
+export default MoveCard;

--- a/packages/TorneloScoresheet/src/components/MoveCard/style.ts
+++ b/packages/TorneloScoresheet/src/components/MoveCard/style.ts
@@ -1,0 +1,33 @@
+import { StyleSheet } from 'react-native';
+import { colours } from '../../style/colour';
+
+export const styles = StyleSheet.create({
+  container: {
+    borderRadius: 4,
+    borderColor: colours.darkGrey,
+    borderWidth: 2,
+    minWidth: 100,
+    alignItems: 'center',
+    marginVertical: 20,
+    marginHorizontal: 5,
+  },
+  moveNumberContainer: {
+    backgroundColor: colours.primary,
+    width: '100%',
+    paddingVertical: 12,
+  },
+  whitePlyContainer: {
+    backgroundColor: colours.lightBlue,
+    borderTopColor: colours.darkGrey,
+    borderTopWidth: 2,
+    width: '100%',
+    paddingVertical: 12,
+  },
+  blackPlyContainer: {
+    borderTopColor: colours.darkGrey,
+    borderTopWidth: 2,
+    width: '100%',
+    paddingVertical: 12,
+    minHeight: 50,
+  },
+});

--- a/packages/TorneloScoresheet/src/components/PrimaryText/PrimaryText.tsx
+++ b/packages/TorneloScoresheet/src/components/PrimaryText/PrimaryText.tsx
@@ -3,43 +3,22 @@ import { StyleProp, Text, TextStyle } from 'react-native';
 import { primary } from '../../style/font';
 
 export enum FontWeight {
-  Thin,
-  ExtraLight,
-  Light,
-  Regular,
-  Medium,
-  SemiBold,
-  Bold,
-  ExtraBold,
-  Black,
+  Thin = '100',
+  ExtraLight = '200',
+  Light = '300',
+  Regular = '400',
+  Medium = '500',
+  SemiBold = '600',
+  Bold = '700',
+  ExtraBold = '800',
+  Black = '900',
 }
 
-const fontWeightStyle = (
-  fontWeight?: FontWeight,
-): '100' | '200' | '300' | '400' | '500' | '600' | '700' | '800' | '900' => {
-  switch (fontWeight) {
-    case FontWeight.Thin:
-      return '100';
-    case FontWeight.ExtraLight:
-      return '200';
-    case FontWeight.Light:
-      return '300';
-    case FontWeight.Regular:
-      return '400';
-    case FontWeight.Medium:
-      return '500';
-    case FontWeight.SemiBold:
-      return '600';
-    case FontWeight.Bold:
-      return '700';
-    case FontWeight.ExtraBold:
-      return '800';
-    case FontWeight.Black:
-      return '900';
-    case undefined:
-      return '400';
-  }
-};
+export enum Align {
+  Center = 'center',
+  Left = 'left',
+  Right = 'right',
+}
 
 type PrimaryTextProps = {
   label?: string;
@@ -47,6 +26,7 @@ type PrimaryTextProps = {
   colour?: string;
   size?: number;
   style?: StyleProp<TextStyle>;
+  align?: Align;
 };
 
 const PrimaryText: React.FC<PrimaryTextProps> = ({
@@ -56,15 +36,17 @@ const PrimaryText: React.FC<PrimaryTextProps> = ({
   style,
   size,
   children,
+  align,
 }) => {
   return (
     <Text
       style={[
         {
-          fontWeight: fontWeightStyle(weight),
+          fontWeight: weight,
           fontFamily: primary,
           color: colour,
           fontSize: size,
+          textAlign: align,
         },
         style,
       ]}>

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/style.ts
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/style.ts
@@ -3,9 +3,12 @@ import { StyleSheet } from 'react-native';
 export const styles = StyleSheet.create({
   mainContainer: {
     display: 'flex',
-    marginHorizontal: 10,
   },
   boardButtonContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+  },
+  moveCardContainer: {
     display: 'flex',
     flexDirection: 'row',
   },

--- a/packages/TorneloScoresheet/src/style/colour.ts
+++ b/packages/TorneloScoresheet/src/style/colour.ts
@@ -16,6 +16,7 @@ export const colours = {
   tertiary: '#ffbf00' as const,
   // Elements Colours
   darkenedElements: '#141414' as const,
+  darkGrey: '#6B6A6E' as const,
   // Chess Board Colours
   darkBlue: '#A2CEE3' as const,
   lightBlue: '#E3ECF3' as const,
@@ -31,6 +32,7 @@ export const statusBarStyleForColor = (colour: ColourType): StatusBarStyle => {
     case colours.negative:
     case colours.darkenedElements:
     case colours.black:
+    case colours.darkGrey:
       return 'light-content';
     case colours.primary20:
     case colours.secondary40:
@@ -58,6 +60,7 @@ export const textColour = (colour: ColourType): string => {
     case colours.black:
     case colours.lightBlue:
     case colours.darkBlue:
+    case colours.darkGrey:
       return 'white';
     case colours.primary20:
     case colours.secondary40:

--- a/packages/TorneloScoresheet/src/types/ChessMove.ts
+++ b/packages/TorneloScoresheet/src/types/ChessMove.ts
@@ -15,6 +15,16 @@ export type Piece = {
   player: PlayerColour;
 };
 
+// We define a move as being either one or two
+// ply - one for white and one for black
+export type Move = {
+  white: ChessPly;
+  black: ChessPly | undefined;
+};
+
+// Here, a move means a piece moving across the board,
+// this type represents the source and destination of
+// a piece being moved
 export type MoveSquares = {
   from: Position;
   to: Position;
@@ -24,6 +34,8 @@ export enum PlyTypes {
   MovePly,
   SkipPly,
 }
+
+// Information about a given ply
 export type PlyInfo = {
   moveNo: number;
   startingFen: string;
@@ -31,14 +43,20 @@ export type PlyInfo = {
   type: PlyTypes;
 };
 
+// A move ply is a recorded ply that involved
+// a piece moving across the board
 export type MovePly = {
   move: MoveSquares;
   type: PlyTypes.MovePly;
   promotion?: PieceType;
 } & PlyInfo;
 
+// A skip ply is a recorded ply that has been
+// marked as "skipped" - i.e. this is a placeholder
+// for a ply will be filled in later
 export type SkipPly = {
   type: PlyTypes.SkipPly;
 } & PlyInfo;
 
+// Either a skip or a piece that is moved
 export type ChessPly = MovePly | SkipPly;


### PR DESCRIPTION
The `MoveCard` component renders the details of a given "move" (one or two ply - one for white and maybe one for black).

The `GraphicalRecordingMode` page makes use of this new component to render all of the moves for the game in a horizontally scrolling list:

https://user-images.githubusercontent.com/57308619/177023289-bee35ff7-d52c-4167-bb2c-f24e382c653e.mov


