### PR TITLE
Primary button loading & PGN fetching network error handling

### DIFF
--- a/packages/TorneloScoresheet/src/components/PrimaryButton/PrimaryButton.tsx
+++ b/packages/TorneloScoresheet/src/components/PrimaryButton/PrimaryButton.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+  ActivityIndicator,
   StyleProp,
   TextStyle,
   TouchableOpacity,
@@ -12,27 +13,43 @@ import { styles } from './style';
 type PrimaryButtonProps = {
   label: string;
   labelStyle?: StyleProp<TextStyle>;
+  loading?: boolean;
 } & TouchableOpacityProps;
 
 const PrimaryButton: React.FC<PrimaryButtonProps> = ({
   label,
   style,
   labelStyle,
+  loading,
   ...touchableOpacityProps
 }) => {
   return (
     <TouchableOpacity
       style={[styles.buttonStyle, style]}
       {...touchableOpacityProps}>
+      {loading && (
+        <ActivityIndicator
+          color={colours.white}
+          style={styles.loadingIndicator}
+          size="large"
+        />
+      )}
       <PrimaryText
         size={30}
         weight={FontWeight.Bold}
-        colour={colours.white}
-        style={[styles.buttonLabel, labelStyle]}
+        style={[
+          styles.buttonLabel,
+          labelStyle,
+          hideIfLoading(loading ?? false),
+        ]}
         label={label}
       />
     </TouchableOpacity>
   );
 };
+
+const hideIfLoading = (loading: boolean) => ({
+  color: loading ? colours.primary : colours.white,
+});
 
 export default PrimaryButton;

--- a/packages/TorneloScoresheet/src/components/PrimaryButton/style.ts
+++ b/packages/TorneloScoresheet/src/components/PrimaryButton/style.ts
@@ -16,4 +16,5 @@ export const styles = StyleSheet.create({
   buttonLabel: {
     textTransform: 'uppercase',
   },
+  loadingIndicator: { position: 'absolute', top: '50%', zIndex: 2 },
 });

--- a/packages/TorneloScoresheet/src/hooks/appMode/enterPgnState.ts
+++ b/packages/TorneloScoresheet/src/hooks/appMode/enterPgnState.ts
@@ -1,4 +1,4 @@
-import axios from 'axios';
+import axios, { AxiosResponse } from 'axios';
 import React, { useContext } from 'react';
 import { chessEngine } from '../../chessEngine/chessEngineInterface';
 import { AppModeState, AppMode, EnterPgnMode } from '../../types/AppModeState';
@@ -22,7 +22,21 @@ const makegoToTablePairingSelection =
       );
     }
     // fetch pgn from api
-    const result = await axios.get(liveLinkUrl, { validateStatus: () => true });
+    const resultOrErr: Result<AxiosResponse> = await (async () => {
+      try {
+        return succ(
+          await axios.get(liveLinkUrl, { validateStatus: () => true }),
+        );
+      } catch (e) {
+        return fail('Network error, please check your internet connection');
+      }
+    })();
+
+    if (isError(resultOrErr)) {
+      return resultOrErr;
+    }
+
+    const result = resultOrErr.data;
 
     if (result.status !== 200 || typeof result.data !== 'string') {
       return fail('Error downloading PGN. Please double check the link');

--- a/packages/TorneloScoresheet/src/pages/EnterPgn/EnterPgn.tsx
+++ b/packages/TorneloScoresheet/src/pages/EnterPgn/EnterPgn.tsx
@@ -20,6 +20,7 @@ import PrimaryText, {
 
 const EnterPgn: React.FC = () => {
   const state = useEnterPgnState();
+  const [loading, setLoading] = useState(false);
   const goToPairingSelection = state?.[1]?.goToPairingSelection;
   const appMode = state?.[0];
 
@@ -38,6 +39,7 @@ const EnterPgn: React.FC = () => {
   }, []);
 
   const handleNextClick = async () => {
+    setLoading(true);
     await storePgnUrl(url);
     if (!goToPairingSelection) {
       return;
@@ -47,6 +49,7 @@ const EnterPgn: React.FC = () => {
 
     if (isError(result)) {
       showError(result.error);
+      setLoading(false);
     }
   };
 
@@ -93,6 +96,7 @@ const EnterPgn: React.FC = () => {
               labelStyle={styles.startButtonLabel}
               onPress={handleNextClick}
               label="Start"
+              loading={loading}
             />
           </View>
         </KeyboardAvoidingView>


### PR DESCRIPTION
We now have a loading state for primary buttons - we make use of this on the `EnterPgn` page when we are fetching the PGN.

We also now gracefully handle network errors when fetching the PGN, rather than crashing

https://user-images.githubusercontent.com/57308619/177024374-12936553-63a1-4407-ac64-309c32f17583.mov


