### PR TITLE
Update transition from Graphical Recording Mode to Result Display Mode

### DIFF
--- a/packages/TorneloScoresheet/src/components/Signature/Signature.tsx
+++ b/packages/TorneloScoresheet/src/components/Signature/Signature.tsx
@@ -1,6 +1,8 @@
 import React, { useRef } from 'react';
 import { View } from 'react-native';
-import SignatureCapture from 'react-native-signature-capture';
+import SignatureCapture, {
+  SaveEventParams,
+} from 'react-native-signature-capture';
 import { colours } from '../../style/colour';
 import PrimaryButton from '../PrimaryButton/PrimaryButton';
 import PrimaryText, { FontWeight } from '../PrimaryText/PrimaryText';
@@ -10,8 +12,8 @@ import { styles } from './style';
 export type SignatureProps = {
   visible: boolean;
   onCancel: () => void;
-  winnerName: string;
-  onConfirm: () => void;
+  winnerName: string | null;
+  onConfirm: (signature: string) => void;
 };
 
 const Signature: React.FC<SignatureProps> = ({
@@ -22,13 +24,11 @@ const Signature: React.FC<SignatureProps> = ({
 }) => {
   const sign = useRef<any>();
 
-  const confirmSign = () => {
-    sign.current.saveImage();
+  const handleSaveSignature = async (event: SaveEventParams) => {
+    const base64Image = `data:image/png;base64,${event.encoded}`;
+    onConfirm(base64Image);
   };
 
-  const resetSign = () => {
-    sign.current.resetImage();
-  };
   return (
     <>
       <Sheet dismiss={onCancel} visible={visible}>
@@ -37,9 +37,13 @@ const Signature: React.FC<SignatureProps> = ({
           weight={FontWeight.Bold}
           size={30}
           colour={colours.darkenedElements}>
-          {'Sign to Confirm Winner: ' + winnerName}
+          {`Sign to confirm ${
+            (winnerName && 'winner: ' + winnerName) ?? 'draw'
+          }`}
         </PrimaryText>
         <SignatureCapture
+          onSaveEvent={handleSaveSignature}
+          saveImageFileInExtStorage={false}
           ref={sign}
           style={styles.signature}
           showNativeButtons={false}
@@ -50,14 +54,13 @@ const Signature: React.FC<SignatureProps> = ({
           <PrimaryButton
             style={styles.buttonStyle}
             onPress={() => {
-              resetSign();
+              sign.current.resetImage();
             }}
             label={'Reset'}></PrimaryButton>
           <PrimaryButton
             style={styles.buttonStyle}
-            onPress={() => {
-              confirmSign();
-              onConfirm();
+            onPress={async () => {
+              sign.current.saveImage();
             }}
             label={'Confirm'}></PrimaryButton>
         </View>

--- a/packages/TorneloScoresheet/src/components/Signature/style.ts
+++ b/packages/TorneloScoresheet/src/components/Signature/style.ts
@@ -21,5 +21,6 @@ export const styles = StyleSheet.create({
   },
   messageText: {
     textAlign: 'center',
+    minWidth: 500,
   },
 });

--- a/packages/TorneloScoresheet/src/hooks/appMode/graphicalRecordingState.ts
+++ b/packages/TorneloScoresheet/src/hooks/appMode/graphicalRecordingState.ts
@@ -5,7 +5,11 @@ import {
   AppModeState,
   GraphicalRecordingMode,
 } from '../../types/AppModeState';
-import { PlayerColour } from '../../types/ChessGameInfo';
+import {
+  ChessGameInfo,
+  ChessGameResult,
+  PlayerColour,
+} from '../../types/ChessGameInfo';
 import {
   ChessPly,
   MovePly,
@@ -18,7 +22,7 @@ import {
 type GraphicalRecordingStateHookType = [
   GraphicalRecordingMode,
   {
-    goToEndGame: () => void;
+    goToEndGame: (result: ChessGameResult) => void;
     goToTextInput: () => void;
     goToArbiterMode: () => void;
     move: (moveSquares: MoveSquares, promotion?: PieceType) => void;
@@ -106,6 +110,15 @@ const processPlayerMove = (
     : [...moveHistory, nextPly];
 };
 
+export const generatePgnFromHistory = (
+  pairing: ChessGameInfo,
+  history: ChessPly[],
+  result: ChessGameResult,
+): string => {
+  // TODO: Implement pgn generation
+  return '';
+};
+
 export const makeUseGraphicalRecordingState =
   (
     context: React.Context<
@@ -127,9 +140,18 @@ export const makeUseGraphicalRecordingState =
       });
     };
 
-    const goToEndGameFunc = (): void => {
+    const goToEndGameFunc = (result: ChessGameResult): void => {
       setAppModeState({
         mode: AppMode.ResultDisplay,
+        pairing: appModeState.pairing,
+        result: {
+          ...result,
+          gamePgn: generatePgnFromHistory(
+            appModeState.pairing,
+            appModeState.moveHistory,
+            result,
+          ),
+        },
       });
     };
     const goToTextInputFunc = (): void => {};

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
@@ -179,11 +179,14 @@ const GraphicalRecording: React.FC = () => {
   };
 
   //Button Functions
-  const handleConfirmWinner = () => {
+  const handleConfirmWinner = (signature: string) => {
     if (!graphicalRecordingMode || !goToEndGame) {
       return;
     } else {
-      goToEndGame();
+      goToEndGame({
+        winner: selectedWinner?.color ?? null,
+        signature: signature,
+      });
     }
   };
 

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
@@ -42,9 +42,6 @@ const GraphicalRecording: React.FC = () => {
   const skipTurnAndProcessMove =
     graphicalRecordingState?.[1].skipTurnAndProcessMove;
 
-  // Scroll view ref
-  const scrollRef = useRef<ScrollView>(null);
-
   // states
   const [flipBoard, setFlipBoard] = useState(
     graphicalRecordingMode?.currentPlayer === PlayerColour.Black,
@@ -56,6 +53,9 @@ const GraphicalRecording: React.FC = () => {
   const [selectedWinner, setSelectedWinner] = useState<
     undefined | Player | null
   >(undefined);
+
+  // Scroll view ref
+  const scrollRef = useRef<ScrollView>(null);
 
   // when the promotion popup opens, the app will await untill a promise is resolved
   // this ref stores this resolve function (it will be called once the user selects a promotion)
@@ -166,19 +166,7 @@ const GraphicalRecording: React.FC = () => {
       ]
     : [];
 
-  /**
-   * this will prompt user to select a promotion piece and will not return until they do
-   */
-  const promptUserForPromotionChoice = (): Promise<PieceType> => {
-    // prompt user to select promotion
-    setShowPromotion(true);
-
-    // create a promise, store the resolve function in the ref
-    // this promise will not return until the resolve function is called by handleSelectPromotion()
-    return new Promise<PieceType>(r => (promotionSelectedFunc.current = r));
-  };
-
-  //Button Functions
+  // Button Functions
   const handleConfirmWinner = (signature: string) => {
     if (!graphicalRecordingMode || !goToEndGame) {
       return;
@@ -201,6 +189,7 @@ const GraphicalRecording: React.FC = () => {
     setShowEndGame(false);
     setSelectedWinner(undefined);
   };
+
   /**
    * function called once the user has selected their promotion from the pop up
    * @param promotion the promotion piece the user has selected
@@ -214,6 +203,18 @@ const GraphicalRecording: React.FC = () => {
     if (promotionSelectedFunc.current !== null) {
       promotionSelectedFunc.current(promotion);
     }
+  };
+
+  /**
+   * this will prompt user to select a promotion piece and will not return until they do
+   */
+  const promptUserForPromotionChoice = (): Promise<PieceType> => {
+    // prompt user to select promotion
+    setShowPromotion(true);
+
+    // create a promise, store the resolve function in the ref
+    // this promise will not return until the resolve function is called by handleSelectPromotion()
+    return new Promise<PieceType>(r => (promotionSelectedFunc.current = r));
   };
 
   const handleMove = async (moveSquares: MoveSquares): Promise<void> => {
@@ -247,35 +248,31 @@ const GraphicalRecording: React.FC = () => {
     <>
       {graphicalRecordingMode && (
         <View style={styles.mainContainer}>
+          {/*----- Popups -----*/}
           <OptionSheet
             visible={showPromotion}
             onCancel={() => setShowPromotion(false)}
             message={'Select Promotion Piece'}
             options={promotionButtons}
           />
+          <OptionSheet
+            message={'Please Select the Winner'}
+            options={endGameOptions}
+            visible={showEndGame}
+            onCancel={handleCancelSelection}
+          />
+          <Signature
+            visible={showSignature}
+            onCancel={handleCancelSelection}
+            winnerName={(selectedWinner && fullName(selectedWinner)) ?? null}
+            onConfirm={handleConfirmWinner}
+          />
+
+          {/*----- body ----- */}
           <View style={{ height: 100, marginLeft: 10 }}>
             <PrimaryText label="Placeholder" size={30} />
           </View>
-          {showEndGame && (
-            <OptionSheet
-              message={'Please Select the Winner'}
-              options={endGameOptions}
-              visible={showEndGame}
-              onCancel={handleCancelSelection}
-            />
-          )}
-          {showSignature && selectedWinner !== undefined && (
-            <>
-              <Signature
-                visible={showSignature}
-                onCancel={handleCancelSelection}
-                winnerName={
-                  (selectedWinner && fullName(selectedWinner)) ?? null
-                }
-                onConfirm={handleConfirmWinner}
-              />
-            </>
-          )}
+
           <View style={styles.boardButtonContainer}>
             <ActionBar actionButtons={actionButtons} />
             <ChessBoard

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
@@ -53,9 +53,9 @@ const GraphicalRecording: React.FC = () => {
   const [showEndGame, setShowEndGame] = useState(false);
   const [showSignature, setShowSignature] = useState(false);
   const goToEndGame = graphicalRecordingState?.[1].goToEndGame;
-  const [selectedWinner, setSelectedWinner] = useState<undefined | Player>(
-    undefined,
-  );
+  const [selectedWinner, setSelectedWinner] = useState<
+    undefined | Player | null
+  >(undefined);
 
   // when the promotion popup opens, the app will await untill a promise is resolved
   // this ref stores this resolve function (it will be called once the user selects a promotion)
@@ -156,8 +156,16 @@ const GraphicalRecording: React.FC = () => {
             width: '100%',
           },
         },
+        {
+          text: 'Draw',
+          onPress: () => handleSelectWinner(null),
+          style: {
+            width: '100%',
+          },
+        },
       ]
     : [];
+
   /**
    * this will prompt user to select a promotion piece and will not return until they do
    */
@@ -179,7 +187,7 @@ const GraphicalRecording: React.FC = () => {
     }
   };
 
-  const handleSelectWinner = (player: Player) => {
+  const handleSelectWinner = (player: Player | null) => {
     setShowSignature(true);
     setShowEndGame(false);
     setSelectedWinner(player);
@@ -253,12 +261,14 @@ const GraphicalRecording: React.FC = () => {
               onCancel={handleCancelSelection}
             />
           )}
-          {showSignature && selectedWinner && (
+          {showSignature && selectedWinner !== undefined && (
             <>
               <Signature
                 visible={showSignature}
                 onCancel={handleCancelSelection}
-                winnerName={fullName(selectedWinner)}
+                winnerName={
+                  (selectedWinner && fullName(selectedWinner)) ?? null
+                }
                 onConfirm={handleConfirmWinner}
               />
             </>

--- a/packages/TorneloScoresheet/src/types/AppModeState.ts
+++ b/packages/TorneloScoresheet/src/types/AppModeState.ts
@@ -1,5 +1,5 @@
 import { BoardPosition } from './ChessBoardPositions';
-import { ChessGameInfo, PlayerColour } from './ChessGameInfo';
+import { ChessGameInfo, ChessGameResult, PlayerColour } from './ChessGameInfo';
 import { ChessPly } from './ChessMove';
 
 export enum AppMode {
@@ -34,6 +34,8 @@ export type GraphicalRecordingMode = {
 
 export type ResultDisplayMode = {
   mode: AppMode.ResultDisplay;
+  pairing: ChessGameInfo;
+  result: ChessGameResult;
 };
 
 export type AppModeState =

--- a/packages/TorneloScoresheet/src/types/ChessGameInfo.ts
+++ b/packages/TorneloScoresheet/src/types/ChessGameInfo.ts
@@ -12,6 +12,12 @@ export type ChessGameInfo = {
   pgn: string;
 };
 
+export type ChessGameResult = {
+  winner: PlayerColour | null;
+  gamePgn?: string;
+  signature: string;
+};
+
 export enum PlayerColour {
   White,
   Black,


### PR DESCRIPTION
**This PR has been changed**
_Instead of storing using AsyncStorage, we will instead pass the base64 images of signatures to the ResultDisplay app mode state_

When the signature is confiremed, it is saved as a base64 image, and then the `GraphicalRecording` page will call the hook's `goToEndGame` method and pass through the winner and the signature of the current player.
As @gwenllian1 mentioned, in the future we might also require the other player and the arbiter to also sign, we can confirm how this should work with David when we see him next and update it accordingly

In the hook's `goToEndGame` function, the code currently calls a `generatePgnFromHistory` function which currently returns an empty string, we will need to implement this function in a separate PR.

This PR also extended the functionality of the end game feature by allowing the user to select a draw

