### PR TITLE
Toggle draw

### DIFF
--- a/packages/TorneloScoresheet/__tests__/useAppModeState.test.ts
+++ b/packages/TorneloScoresheet/__tests__/useAppModeState.test.ts
@@ -131,6 +131,7 @@ describe('graphical recording moving', () => {
             move,
             type: PlyTypes.MovePly,
             player: PlayerColour.White,
+            drawOffer: false,
           },
         ],
       });
@@ -149,6 +150,7 @@ describe('graphical recording moving', () => {
         startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
         move: { from: 'a1', to: 'a5' } as MoveSquares,
         type: PlyTypes.MovePly,
+        drawOffer: false,
       },
     ];
 
@@ -171,6 +173,7 @@ describe('graphical recording moving', () => {
             startingFen:
               'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
             move: { from: 'a1', to: 'a5' } as MoveSquares,
+            drawOffer: false,
           },
           {
             moveNo: 1,
@@ -178,6 +181,7 @@ describe('graphical recording moving', () => {
             type: PlyTypes.MovePly,
             startingFen: originFen,
             move,
+            drawOffer: false,
           },
         ],
       });
@@ -209,6 +213,7 @@ describe('undoing last move', () => {
         startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
         type: PlyTypes.MovePly,
         move: { from: 'a1', to: 'a5' } as MoveSquares,
+        drawOffer: false,
       },
     ];
     const graphicalState = generateGraphicalRecordingState(moveHistory);
@@ -233,6 +238,7 @@ describe('undoing last move', () => {
         type: PlyTypes.MovePly,
         startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
         move: { from: 'a1', to: 'a5' } as MoveSquares,
+        drawOffer: false,
       },
       {
         moveNo: 1,
@@ -240,6 +246,7 @@ describe('undoing last move', () => {
         startingFen: 'rnbqkbnr/pppppppp/8/R7/8/8/PPPPPPPP/1NBQKBNR b Kkq - 1 1',
         move: { from: 'h8', to: 'h5' } as MoveSquares,
         type: PlyTypes.MovePly,
+        drawOffer: false,
       },
     ];
     const graphicalState = generateGraphicalRecordingState(moveHistory);
@@ -262,6 +269,7 @@ describe('undoing last move', () => {
             startingFen:
               'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
             move: { from: 'a1', to: 'a5' } as MoveSquares,
+            drawOffer: false,
           },
         ],
       });
@@ -289,6 +297,7 @@ describe('Skipping player turn', () => {
             player: PlayerColour.White,
             startingFen,
             type: PlyTypes.SkipPly,
+            drawOffer: false,
           },
         ],
         board: chessEngine.fenToBoardPositions(resultingFen),
@@ -304,6 +313,7 @@ describe('Skipping player turn', () => {
         startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
         type: PlyTypes.MovePly,
         move: { from: 'a1', to: 'a5' } as MoveSquares,
+        drawOffer: false,
       },
     ];
     const graphicalState = generateGraphicalRecordingState(moveHistory);
@@ -326,6 +336,7 @@ describe('Skipping player turn', () => {
             player: PlayerColour.Black,
             startingFen,
             type: PlyTypes.SkipPly,
+            drawOffer: false,
           },
         ],
         board: chessEngine.fenToBoardPositions(resultingFen),
@@ -360,6 +371,7 @@ describe('Auto Skip player turn', () => {
             player: PlayerColour.White,
             startingFen,
             type: PlyTypes.SkipPly,
+            drawOffer: false,
           },
           {
             moveNo: 1,
@@ -367,6 +379,7 @@ describe('Auto Skip player turn', () => {
             startingFen: afterSkipResultingFen,
             type: PlyTypes.MovePly,
             move,
+            drawOffer: false,
           },
         ],
         board: chessEngine.fenToBoardPositions(afterMoveResultingFen),
@@ -388,6 +401,7 @@ describe('Auto Skip player turn', () => {
         startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
         type: PlyTypes.MovePly,
         move: { from: 'a1', to: 'a5' } as MoveSquares,
+        drawOffer: false,
       },
     ];
     const move = { from: 'a5', to: 'a6' } as MoveSquares;
@@ -407,6 +421,7 @@ describe('Auto Skip player turn', () => {
             player: PlayerColour.Black,
             startingFen,
             type: PlyTypes.SkipPly,
+            drawOffer: false,
           },
           {
             moveNo: 2,
@@ -414,6 +429,7 @@ describe('Auto Skip player turn', () => {
             type: PlyTypes.MovePly,
             move,
             startingFen: afterSkipResultingFen,
+            drawOffer: false,
           },
         ],
         board: chessEngine.fenToBoardPositions(afterMoveResultingFen),
@@ -445,6 +461,7 @@ describe('Auto Skip player turn', () => {
             player: PlayerColour.White,
             startingFen,
             type: PlyTypes.SkipPly,
+            drawOffer: false,
           },
         ],
         board: chessEngine.fenToBoardPositions(afterSkipResultingFen),
@@ -465,6 +482,7 @@ describe('Auto Skip player turn', () => {
         startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
         type: PlyTypes.MovePly,
         move: { from: 'a1', to: 'a5' } as MoveSquares,
+        drawOffer: false,
       },
     ];
     const move = { from: 'a5', to: 'b1' } as MoveSquares;
@@ -484,6 +502,7 @@ describe('Auto Skip player turn', () => {
             player: PlayerColour.Black,
             startingFen,
             type: PlyTypes.SkipPly,
+            drawOffer: false,
           },
         ],
         board: chessEngine.fenToBoardPositions(afterSkipResultingFen),
@@ -505,6 +524,7 @@ describe('Auto Skip player turn', () => {
         startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
         type: PlyTypes.MovePly,
         move: { from: 'a1', to: 'a5' } as MoveSquares,
+        drawOffer: false,
       },
     ];
     const move = { from: 'a2', to: 'a8' } as MoveSquares;
@@ -527,6 +547,7 @@ describe('Auto Skip player turn', () => {
             player: PlayerColour.Black,
             startingFen,
             type: PlyTypes.SkipPly,
+            drawOffer: false,
           },
           {
             moveNo: 2,
@@ -535,6 +556,7 @@ describe('Auto Skip player turn', () => {
             move,
             promotion: PieceType.Queen,
             startingFen: afterSkipResultingFen,
+            drawOffer: false,
           },
         ],
         board: chessEngine.fenToBoardPositions(afterMoveResultingFen),
@@ -1230,6 +1252,188 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
         mode: AppMode.ResultDisplay,
         result,
         pairing: graphicalState.pairing,
+      });
+    });
+  });
+});
+
+describe('Toggle Draw Offer', () => {
+  test('Add draw offer on white move', () => {
+    const moveHistory = [
+      {
+        moveNo: 1,
+        player: PlayerColour.White,
+        startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+        type: PlyTypes.MovePly,
+        move: { from: 'a1', to: 'a5' } as MoveSquares,
+        drawOffer: false,
+      },
+    ];
+    const graphicalState = generateGraphicalRecordingState(moveHistory);
+    const setContextMock = mockAppModeContext(graphicalState);
+    const graphicalStateHook = renderCustomHook(useGraphicalRecordingState);
+
+    act(() => {
+      graphicalStateHook.current?.[1].toggleDraw(0);
+      expect(setContextMock).toHaveBeenCalledTimes(1);
+      expect(setContextMock).toHaveBeenCalledWith({
+        ...graphicalState,
+        moveHistory: [
+          {
+            moveNo: 1,
+            player: PlayerColour.White,
+            startingFen:
+              'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+            type: PlyTypes.MovePly,
+            move: { from: 'a1', to: 'a5' } as MoveSquares,
+            drawOffer: true,
+          },
+        ],
+      });
+    });
+  });
+
+  test('Remove draw offer on white move', () => {
+    const moveHistory = [
+      {
+        moveNo: 1,
+        player: PlayerColour.White,
+        startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+        type: PlyTypes.MovePly,
+        move: { from: 'a1', to: 'a5' } as MoveSquares,
+        drawOffer: true,
+      },
+    ];
+    const graphicalState = generateGraphicalRecordingState(moveHistory);
+    const setContextMock = mockAppModeContext(graphicalState);
+    const graphicalStateHook = renderCustomHook(useGraphicalRecordingState);
+
+    act(() => {
+      graphicalStateHook.current?.[1].toggleDraw(0);
+      expect(setContextMock).toHaveBeenCalledTimes(1);
+      expect(setContextMock).toHaveBeenCalledWith({
+        ...graphicalState,
+        moveHistory: [
+          {
+            moveNo: 1,
+            player: PlayerColour.White,
+            startingFen:
+              'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+            type: PlyTypes.MovePly,
+            move: { from: 'a1', to: 'a5' } as MoveSquares,
+            drawOffer: false,
+          },
+        ],
+      });
+    });
+  });
+
+  test('offer draw black move', () => {
+    const moveHistory = [
+      {
+        moveNo: 1,
+        player: PlayerColour.White,
+        type: PlyTypes.MovePly,
+        startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+        move: { from: 'a1', to: 'a5' } as MoveSquares,
+        drawOffer: false,
+      },
+      {
+        moveNo: 1,
+        player: PlayerColour.Black,
+        startingFen: 'rnbqkbnr/pppppppp/8/R7/8/8/PPPPPPPP/1NBQKBNR b Kkq - 1 1',
+        move: { from: 'h8', to: 'h5' } as MoveSquares,
+        type: PlyTypes.MovePly,
+        drawOffer: false,
+      },
+    ];
+    const graphicalState = generateGraphicalRecordingState(moveHistory);
+    const setContextMock = mockAppModeContext(graphicalState);
+    const graphicalStateHook = renderCustomHook(useGraphicalRecordingState);
+
+    act(() => {
+      graphicalStateHook.current?.[1].undoLastMove();
+      expect(setContextMock).toHaveBeenCalledTimes(1);
+      expect(setContextMock).toHaveBeenCalledWith({
+        ...graphicalState,
+        board: chessEngine.fenToBoardPositions(
+          'rnbqkbnr/pppppppp/8/R7/8/8/PPPPPPPP/1NBQKBNR b Kkq - 1 1',
+        ),
+        moveHistory: [
+          {
+            moveNo: 1,
+            player: PlayerColour.White,
+            type: PlyTypes.MovePly,
+            startingFen:
+              'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+            move: { from: 'a1', to: 'a5' } as MoveSquares,
+            drawOffer: false,
+          },
+          {
+            moveNo: 1,
+            player: PlayerColour.Black,
+            startingFen:
+              'rnbqkbnr/pppppppp/8/R7/8/8/PPPPPPPP/1NBQKBNR b Kkq - 1 1',
+            move: { from: 'h8', to: 'h5' } as MoveSquares,
+            type: PlyTypes.MovePly,
+            drawOffer: true,
+          },
+        ],
+      });
+    });
+  });
+
+  test('remove draw offer black move', () => {
+    const moveHistory = [
+      {
+        moveNo: 1,
+        player: PlayerColour.White,
+        type: PlyTypes.MovePly,
+        startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+        move: { from: 'a1', to: 'a5' } as MoveSquares,
+        drawOffer: false,
+      },
+      {
+        moveNo: 1,
+        player: PlayerColour.Black,
+        startingFen: 'rnbqkbnr/pppppppp/8/R7/8/8/PPPPPPPP/1NBQKBNR b Kkq - 1 1',
+        move: { from: 'h8', to: 'h5' } as MoveSquares,
+        type: PlyTypes.MovePly,
+        drawOffer: true,
+      },
+    ];
+    const graphicalState = generateGraphicalRecordingState(moveHistory);
+    const setContextMock = mockAppModeContext(graphicalState);
+    const graphicalStateHook = renderCustomHook(useGraphicalRecordingState);
+
+    act(() => {
+      graphicalStateHook.current?.[1].undoLastMove();
+      expect(setContextMock).toHaveBeenCalledTimes(1);
+      expect(setContextMock).toHaveBeenCalledWith({
+        ...graphicalState,
+        board: chessEngine.fenToBoardPositions(
+          'rnbqkbnr/pppppppp/8/R7/8/8/PPPPPPPP/1NBQKBNR b Kkq - 1 1',
+        ),
+        moveHistory: [
+          {
+            moveNo: 1,
+            player: PlayerColour.White,
+            type: PlyTypes.MovePly,
+            startingFen:
+              'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+            move: { from: 'a1', to: 'a5' } as MoveSquares,
+            drawOffer: false,
+          },
+          {
+            moveNo: 1,
+            player: PlayerColour.Black,
+            startingFen:
+              'rnbqkbnr/pppppppp/8/R7/8/8/PPPPPPPP/1NBQKBNR b Kkq - 1 1',
+            move: { from: 'h8', to: 'h5' } as MoveSquares,
+            type: PlyTypes.MovePly,
+            drawOffer: false,
+          },
+        ],
       });
     });
   });

--- a/packages/TorneloScoresheet/__tests__/useAppModeState.test.ts
+++ b/packages/TorneloScoresheet/__tests__/useAppModeState.test.ts
@@ -693,7 +693,7 @@ describe('Generate pgn', () => {
       ] as ChessPly[],
       pgnSucess,
     );
-    const setContextMock = mockAppModeContext(graphicalState);
+    mockAppModeContext(graphicalState);
     const graphicalStateHook = renderCustomHook(useGraphicalRecordingState);
     act(() => {
       const pgnResult = graphicalStateHook.current?.[1].generatePgn(
@@ -830,7 +830,7 @@ describe('Generate pgn', () => {
       ] as ChessPly[],
       pgnSucess,
     );
-    const setContextMock = mockAppModeContext(graphicalState);
+    mockAppModeContext(graphicalState);
 
     const graphicalStateHook = renderCustomHook(useGraphicalRecordingState);
     act(() => {
@@ -1276,7 +1276,8 @@ describe('Toggle Draw Offer', () => {
     act(() => {
       graphicalStateHook.current?.[1].toggleDraw(0);
       expect(setContextMock).toHaveBeenCalledTimes(1);
-      expect(setContextMock).toHaveBeenCalledWith({
+      expect(typeof setContextMock.mock.calls[0][0]).toBe('function');
+      expect(setContextMock.mock.calls[0][0](graphicalState)).toEqual({
         ...graphicalState,
         moveHistory: [
           {
@@ -1311,7 +1312,8 @@ describe('Toggle Draw Offer', () => {
     act(() => {
       graphicalStateHook.current?.[1].toggleDraw(0);
       expect(setContextMock).toHaveBeenCalledTimes(1);
-      expect(setContextMock).toHaveBeenCalledWith({
+      expect(typeof setContextMock.mock.calls[0][0]).toBe('function');
+      expect(setContextMock.mock.calls[0][0](graphicalState)).toEqual({
         ...graphicalState,
         moveHistory: [
           {
@@ -1352,9 +1354,10 @@ describe('Toggle Draw Offer', () => {
     const graphicalStateHook = renderCustomHook(useGraphicalRecordingState);
 
     act(() => {
-      graphicalStateHook.current?.[1].undoLastMove();
+      graphicalStateHook.current?.[1].toggleDraw(1);
       expect(setContextMock).toHaveBeenCalledTimes(1);
-      expect(setContextMock).toHaveBeenCalledWith({
+      expect(typeof setContextMock.mock.calls[0][0]).toBe('function');
+      expect(setContextMock.mock.calls[0][0](graphicalState)).toEqual({
         ...graphicalState,
         board: chessEngine.fenToBoardPositions(
           'rnbqkbnr/pppppppp/8/R7/8/8/PPPPPPPP/1NBQKBNR b Kkq - 1 1',
@@ -1407,9 +1410,10 @@ describe('Toggle Draw Offer', () => {
     const graphicalStateHook = renderCustomHook(useGraphicalRecordingState);
 
     act(() => {
-      graphicalStateHook.current?.[1].undoLastMove();
+      graphicalStateHook.current?.[1].toggleDraw(1);
       expect(setContextMock).toHaveBeenCalledTimes(1);
-      expect(setContextMock).toHaveBeenCalledWith({
+      expect(typeof setContextMock.mock.calls[0][0]).toBe('function');
+      expect(setContextMock.mock.calls[0][0](graphicalState)).toEqual({
         ...graphicalState,
         board: chessEngine.fenToBoardPositions(
           'rnbqkbnr/pppppppp/8/R7/8/8/PPPPPPPP/1NBQKBNR b Kkq - 1 1',

--- a/packages/TorneloScoresheet/src/chessEngine/chessTsChessEngine.ts
+++ b/packages/TorneloScoresheet/src/chessEngine/chessTsChessEngine.ts
@@ -183,7 +183,7 @@ const generatePgn = (
     return pgn.substring(0, pgn.length - 1);
   };
 
-  const getResultString = (winner: PlayerColour | null): string => {
+  const getResultString = (): string => {
     switch (winner) {
       case PlayerColour.Black:
         return '0-1';
@@ -217,13 +217,13 @@ const generatePgn = (
       }
       return '';
     })
-    .find(error => error !== '');
+    .find(errorMessage => errorMessage !== '');
 
   if (error) {
     return fail(error);
   }
 
-  const pgn = stripStarFromPgn(game.pgn()) + getResultString(winner);
+  const pgn = stripStarFromPgn(game.pgn()) + getResultString();
   return succ(pgn);
 };
 

--- a/packages/TorneloScoresheet/src/components/ActionButton/ActionButton.tsx
+++ b/packages/TorneloScoresheet/src/components/ActionButton/ActionButton.tsx
@@ -1,5 +1,5 @@
 import { View } from 'react-native';
-import { Color, SvgProps } from 'react-native-svg';
+import { SvgProps } from 'react-native-svg';
 import { colours } from '../../style/colour';
 import PrimaryText, { FontWeight } from '../PrimaryText/PrimaryText';
 import RoundedView from '../RoundedView/RoundedView';

--- a/packages/TorneloScoresheet/src/components/MoveCard/MoveCard.tsx
+++ b/packages/TorneloScoresheet/src/components/MoveCard/MoveCard.tsx
@@ -66,7 +66,7 @@ const moveString = (ply: ChessPly): string => {
 
 const blackPlyBackgroundColour = (ply: ChessPly | undefined) => ({
   backgroundColor: ply ? colours.darkBlue : colours.tertiary,
-  paddingBottom: 15,
+  paddingBottom: ply ? 0 : 5,
 });
 
 export default MoveCard;

--- a/packages/TorneloScoresheet/src/components/MoveCard/MoveCard.tsx
+++ b/packages/TorneloScoresheet/src/components/MoveCard/MoveCard.tsx
@@ -21,11 +21,13 @@ const MoveCard: React.FC<MoveCardProps> = ({ move }) => {
       <View
         style={[
           styles.whitePlyContainer,
-          { paddingVertical: move.white.drawOffer ? 0 : 12 },
+          {
+            paddingTop: move.white.drawOffer ? 0 : 16,
+          },
         ]}>
         <View style={styles.containerIcon}>
           {move.white.drawOffer && (
-            <Icon name={'creative-commons-noderivs'} size={20} color="black" />
+            <Icon name={'creative-commons-noderivs'} size={15} color="black" />
           )}
         </View>
         <PrimaryText size={20} align={Align.Center} weight={FontWeight.Bold}>
@@ -36,12 +38,12 @@ const MoveCard: React.FC<MoveCardProps> = ({ move }) => {
       <View
         style={[
           styles.blackPlyContainer,
-          { paddingVertical: move.black && move.black.drawOffer ? 2 : 13 },
+          { paddingTop: move.black && move.black.drawOffer ? 0 : 16 },
           blackPlyBackgroundColour(move.black),
         ]}>
         <View style={styles.containerIcon}>
           {move.black && move.black.drawOffer && (
-            <Icon name={'creative-commons-noderivs'} size={20} color="black" />
+            <Icon name={'creative-commons-noderivs'} size={15} color="black" />
           )}
         </View>
         {move.black && (
@@ -64,6 +66,7 @@ const moveString = (ply: ChessPly): string => {
 
 const blackPlyBackgroundColour = (ply: ChessPly | undefined) => ({
   backgroundColor: ply ? colours.darkBlue : colours.tertiary,
+  paddingBottom: 15,
 });
 
 export default MoveCard;

--- a/packages/TorneloScoresheet/src/components/MoveCard/MoveCard.tsx
+++ b/packages/TorneloScoresheet/src/components/MoveCard/MoveCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View } from 'react-native';
+import Icon from 'react-native-vector-icons/Entypo';
 import { colours } from '../../style/colour';
 import { ChessPly, Move, PlyTypes } from '../../types/ChessMove';
 import PrimaryText, { Align, FontWeight } from '../PrimaryText/PrimaryText';
@@ -17,16 +18,32 @@ const MoveCard: React.FC<MoveCardProps> = ({ move }) => {
           # {move.white.moveNo}
         </PrimaryText>
       </View>
-      <View style={styles.whitePlyContainer}>
+      <View
+        style={[
+          styles.whitePlyContainer,
+          { paddingVertical: move.white.drawOffer ? 0 : 12 },
+        ]}>
+        <View style={styles.containerIcon}>
+          {move.white.drawOffer && (
+            <Icon name={'creative-commons-noderivs'} size={20} color="black" />
+          )}
+        </View>
         <PrimaryText size={20} align={Align.Center} weight={FontWeight.Bold}>
           {moveString(move.white)}
         </PrimaryText>
       </View>
+
       <View
         style={[
           styles.blackPlyContainer,
+          { paddingVertical: move.black && move.black.drawOffer ? 2 : 13 },
           blackPlyBackgroundColour(move.black),
         ]}>
+        <View style={styles.containerIcon}>
+          {move.black && move.black.drawOffer && (
+            <Icon name={'creative-commons-noderivs'} size={20} color="black" />
+          )}
+        </View>
         {move.black && (
           <PrimaryText size={20} align={Align.Center} weight={FontWeight.Bold}>
             {moveString(move.black)}

--- a/packages/TorneloScoresheet/src/components/MoveCard/style.ts
+++ b/packages/TorneloScoresheet/src/components/MoveCard/style.ts
@@ -14,19 +14,21 @@ export const styles = StyleSheet.create({
   moveNumberContainer: {
     backgroundColor: colours.primary,
     width: '100%',
-    paddingVertical: 12,
+    paddingVertical: 2,
   },
   whitePlyContainer: {
     backgroundColor: colours.lightBlue,
     borderTopColor: colours.darkGrey,
     borderTopWidth: 2,
     width: '100%',
+    paddingBottom: 16,
   },
   blackPlyContainer: {
     borderTopColor: colours.darkGrey,
     borderTopWidth: 2,
     width: '100%',
     minHeight: 50,
+    paddingBottom: 16,
   },
   containerIcon: {
     alignItems: 'flex-end',

--- a/packages/TorneloScoresheet/src/components/MoveCard/style.ts
+++ b/packages/TorneloScoresheet/src/components/MoveCard/style.ts
@@ -21,13 +21,14 @@ export const styles = StyleSheet.create({
     borderTopColor: colours.darkGrey,
     borderTopWidth: 2,
     width: '100%',
-    paddingVertical: 12,
   },
   blackPlyContainer: {
     borderTopColor: colours.darkGrey,
     borderTopWidth: 2,
     width: '100%',
-    paddingVertical: 12,
     minHeight: 50,
+  },
+  containerIcon: {
+    alignItems: 'flex-end',
   },
 });

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
@@ -55,7 +55,6 @@ const GraphicalRecording: React.FC = () => {
   const [, showError] = useError();
   const [showEndGame, setShowEndGame] = useState(false);
   const [showSignature, setShowSignature] = useState(false);
-  const [showToggleDrawOffer, setShowToggleDrawOffer] = useState(false);
   const goToEndGame = graphicalRecordingState?.[1].goToEndGame;
   const [selectedWinner, setSelectedWinner] = useState<
     undefined | Player | null
@@ -99,7 +98,12 @@ const GraphicalRecording: React.FC = () => {
     {
       text: 'draw',
       onPress: () => {
-        setShowToggleDrawOffer(true);
+        if (!toggleDraw || !graphicalRecordingMode) {
+          return;
+        }
+        //TODO: In the future this should be changed to the index of the selected move.
+        // Currently it is the most recent move.
+        handleToggleDraw(graphicalRecordingMode.moveHistory.length - 1);
       },
       Icon: ICON_HALF,
       buttonHeight: ButtonHeight.SINGLE,
@@ -144,18 +148,6 @@ const GraphicalRecording: React.FC = () => {
       onPress: () => handleSelectPromotion(PieceType.Bishop),
     },
   ];
-
-  const toggleDrawOptions = graphicalRecordingMode
-    ? [
-        {
-          text: 'Confirm',
-          onPress: () =>
-            handleToggleDraw(graphicalRecordingMode.moveHistory.length - 1),
-          style: { width: '70%' },
-        },
-      ]
-    : [];
-
   const endGameOptions = graphicalRecordingMode
     ? [
         {
@@ -222,12 +214,7 @@ const GraphicalRecording: React.FC = () => {
     setSelectedWinner(undefined);
   };
 
-  const handleCancelToggleDraw = () => {
-    setShowToggleDrawOffer(false);
-  };
-
   const handleToggleDraw = (drawIndex: number) => {
-    setShowToggleDrawOffer(false);
     if (!toggleDraw) {
       return;
     }
@@ -304,12 +291,6 @@ const GraphicalRecording: React.FC = () => {
             options={endGameOptions}
             visible={showEndGame}
             onCancel={handleCancelSelection}
-          />
-          <OptionSheet
-            message={'Confirm Toggle Draw Offer'}
-            options={toggleDrawOptions}
-            visible={showToggleDrawOffer}
-            onCancel={handleCancelToggleDraw}
           />
           <Signature
             visible={showSignature}

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
@@ -9,7 +9,6 @@ import {
 import ChessBoard from '../../components/ChessBoard/ChessBoard';
 import MoveCard from '../../components/MoveCard/MoveCard';
 import OptionSheet from '../../components/OptionSheet/OptionSheet';
-import PrimaryText from '../../components/PrimaryText/PrimaryText';
 import { useGraphicalRecordingState } from '../../context/AppModeStateContext';
 import {
   BISHOP,
@@ -44,6 +43,7 @@ const GraphicalRecording: React.FC = () => {
   const skipTurnAndProcessMove =
     graphicalRecordingState?.[1].skipTurnAndProcessMove;
   const generatePgn = graphicalRecordingState?.[1].generatePgn;
+  const toggleDraw = graphicalRecordingState?.[1].toggleDraw;
 
   // states
   const [flipBoard, setFlipBoard] = useState(
@@ -54,6 +54,7 @@ const GraphicalRecording: React.FC = () => {
   const [, showError] = useError();
   const [showEndGame, setShowEndGame] = useState(false);
   const [showSignature, setShowSignature] = useState(false);
+  const [showToggleDrawOffer, setShowToggleDrawOffer] = useState(false);
   const goToEndGame = graphicalRecordingState?.[1].goToEndGame;
   const [selectedWinner, setSelectedWinner] = useState<
     undefined | Player | null
@@ -97,7 +98,7 @@ const GraphicalRecording: React.FC = () => {
     {
       text: 'draw',
       onPress: () => {
-        return;
+        setShowToggleDrawOffer(true);
       },
       Icon: ICON_HALF,
       buttonHeight: ButtonHeight.SINGLE,
@@ -142,6 +143,17 @@ const GraphicalRecording: React.FC = () => {
       onPress: () => handleSelectPromotion(PieceType.Bishop),
     },
   ];
+
+  const toggleDrawOptions = graphicalRecordingMode
+    ? [
+        {
+          text: 'Confirm',
+          onPress: () =>
+            handleToggleDraw(graphicalRecordingMode.moveHistory.length - 1),
+          style: { width: '70%' },
+        },
+      ]
+    : [];
 
   const endGameOptions = graphicalRecordingMode
     ? [
@@ -207,6 +219,18 @@ const GraphicalRecording: React.FC = () => {
     setShowSignature(false);
     setShowEndGame(false);
     setSelectedWinner(undefined);
+  };
+
+  const handleCancelToggleDraw = () => {
+    setShowToggleDrawOffer(false);
+  };
+
+  const handleToggleDraw = (drawIndex: number) => {
+    setShowToggleDrawOffer(false);
+    if (!toggleDraw) {
+      return;
+    }
+    toggleDraw(drawIndex);
   };
 
   /**
@@ -280,6 +304,12 @@ const GraphicalRecording: React.FC = () => {
             visible={showEndGame}
             onCancel={handleCancelSelection}
           />
+          <OptionSheet
+            message={'Confirm Toggle Draw'}
+            options={toggleDrawOptions}
+            visible={showToggleDrawOffer}
+            onCancel={handleCancelToggleDraw}
+          />
           <Signature
             visible={showSignature}
             onCancel={handleCancelSelection}
@@ -288,9 +318,9 @@ const GraphicalRecording: React.FC = () => {
           />
 
           {/*----- body ----- */}
-          <View style={{ height: 100, marginLeft: 10 }}>
+          {/* <View style={{ height: 100, marginLeft: 10 }}>
             <PrimaryText label="Placeholder" size={30} />
-          </View>
+          </View> */}
 
           <View style={styles.boardButtonContainer}>
             <ActionBar actionButtons={actionButtons} />

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
@@ -30,6 +30,7 @@ import { fullName } from '../../util/player';
 import Signature from '../../components/Signature/Signature';
 import { isError } from '../../types/Result';
 import { useError } from '../../context/ErrorContext';
+import PrimaryText from '../../components/PrimaryText/PrimaryText';
 
 const GraphicalRecording: React.FC = () => {
   // app mode hook unpacking
@@ -316,12 +317,10 @@ const GraphicalRecording: React.FC = () => {
             winnerName={(selectedWinner && fullName(selectedWinner)) ?? null}
             onConfirm={handleConfirmWinner}
           />
-
           {/*----- body ----- */}
-          {/* <View style={{ height: 100, marginLeft: 10 }}>
+          <View style={{ height: 100, marginLeft: 10 }}>
             <PrimaryText label="Placeholder" size={30} />
-          </View> */}
-
+          </View>
           <View style={styles.boardButtonContainer}>
             <ActionBar actionButtons={actionButtons} />
             <ChessBoard

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
@@ -306,7 +306,7 @@ const GraphicalRecording: React.FC = () => {
             onCancel={handleCancelSelection}
           />
           <OptionSheet
-            message={'Confirm Toggle Draw'}
+            message={'Confirm Toggle Draw Offer'}
             options={toggleDrawOptions}
             visible={showToggleDrawOffer}
             onCancel={handleCancelToggleDraw}

--- a/packages/TorneloScoresheet/src/types/ChessMove.ts
+++ b/packages/TorneloScoresheet/src/types/ChessMove.ts
@@ -41,6 +41,7 @@ export type PlyInfo = {
   startingFen: string;
   player: PlayerColour;
   type: PlyTypes;
+  drawOffer: boolean;
 };
 
 // A move ply is a recorded ply that involved

--- a/packages/TorneloScoresheet/testUtils/testUtils.ts
+++ b/packages/TorneloScoresheet/testUtils/testUtils.ts
@@ -70,7 +70,7 @@ export const generateGraphicalRecordingState = (
     pairing: generateGamePairingInfo(pgn),
     moveHistory: moveHistory,
     board: chessEngine.fenToBoardPositions(
-      'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+      moveHistory.at(-1)?.startingFen ?? chessEngine.startingFen(),
     ),
     currentPlayer: PlayerColour.White,
   };


### PR DESCRIPTION


https://user-images.githubusercontent.com/64511606/179705184-9d17d146-b1a1-42ab-9dac-135b9397f648.mp4


Implemented the offer draw functionality. It either adds a draw offer or removes it depending on if there already is one for the move. 

The draw offer function in the graphical recording hook takes the index of the move and updates the draw offer status. Currently, I'm just passing the last move in the list but in the future when we implement the 'go back and edit any move' functionality we should be able to pass the index of any selected move. 

For the video, I removed the placeholder in graphical recording mode because my emulator doesn't show the full move card with it there.