### PR TITLE
Implemented Lock app on exit

### DIFF
--- a/packages/TorneloScoresheet/App.tsx
+++ b/packages/TorneloScoresheet/App.tsx
@@ -8,6 +8,8 @@ import { AppModeStateContextProvider } from './src/context/AppModeStateContext';
 import { ErrorContextProvider } from './src/context/ErrorContext';
 import Main from './src/pages/Main';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import LockAppOnExit from './src/components/LockAppOnExit/LockAppOnExit';
+import { ModalStackContextProvider } from './src/context/ModalStackContext';
 
 const App = () => {
   const isDarkMode = useColorScheme() === 'dark';
@@ -19,13 +21,17 @@ const App = () => {
   return (
     <GestureHandlerRootView>
       <ErrorContextProvider>
-        <AppModeStateContextProvider>
-          <Toolbar />
-          <SafeAreaView style={backgroundStyle}>
-            <Main />
-          </SafeAreaView>
-          <ErrorToast />
-        </AppModeStateContextProvider>
+        <ModalStackContextProvider>
+          <AppModeStateContextProvider>
+            <LockAppOnExit>
+              <Toolbar />
+              <SafeAreaView style={backgroundStyle}>
+                <Main />
+              </SafeAreaView>
+              <ErrorToast />
+            </LockAppOnExit>
+          </AppModeStateContextProvider>
+        </ModalStackContextProvider>
       </ErrorContextProvider>
     </GestureHandlerRootView>
   );

--- a/packages/TorneloScoresheet/src/components/LockAppOnExit/LockAppOnExit.tsx
+++ b/packages/TorneloScoresheet/src/components/LockAppOnExit/LockAppOnExit.tsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { AppState, View } from 'react-native';
+import { useCurrentAppMode } from '../../context/AppModeStateContext';
+import { isArbiterMode } from '../../types/AppModeState';
+import Pin from '../Pin/Pin';
+import Sheet from '../Sheet/Sheet';
+
+type LockAppOnExitProps = {
+  children: React.ReactNode;
+};
+
+const LockAppOnExit = ({ children }: LockAppOnExitProps) => {
+  const appState = useRef(AppState.currentState);
+  const currentAppMode = useCurrentAppMode();
+  const [locked, setLocked] = useState(false);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', nextAppState => {
+      if (
+        nextAppState.match(/inactive|background/) &&
+        appState.current === 'active' &&
+        !isArbiterMode(currentAppMode)
+      ) {
+        setLocked(true);
+      }
+
+      appState.current = nextAppState;
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [currentAppMode]);
+
+  return (
+    <View>
+      <Sheet visible={locked} title="App Locked">
+        <Pin onPress={() => setLocked(false)} />
+      </Sheet>
+      {children}
+    </View>
+  );
+};
+
+export default LockAppOnExit;

--- a/packages/TorneloScoresheet/src/components/Sheet/Sheet.tsx
+++ b/packages/TorneloScoresheet/src/components/Sheet/Sheet.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Modal, View } from 'react-native';
+import { useModal } from '../../context/ModalStackContext';
 import IconButton from '../IconButton/IconButton';
 import PrimaryText, { FontWeight } from '../PrimaryText/PrimaryText';
 import { styles } from './style';
@@ -11,27 +12,29 @@ import { styles } from './style';
 export type SheetProps = {
   visible: boolean;
   title?: string;
-  dismiss: () => void;
+  dismiss?: () => void;
 };
 
 const Sheet: React.FC<SheetProps> = ({ visible, children, dismiss, title }) => {
+  // We want each sheet instance to have a unique ID
+  const [uid] = useState<string>(`${Date.now()}+${Math.random()}`);
+  // So that it can be uniquely identified in the modal stack
+  const { shown } = useModal(uid, visible);
+
   return (
-    <Modal transparent={true} animationType="fade" visible={visible}>
+    <Modal transparent animationType="fade" visible={shown}>
       <View style={styles.backdrop}>
         <View style={styles.contentContainer}>
           <View style={styles.header}>
-            <PrimaryText
-              size={30}
-              weight={FontWeight.Bold}
-              style={styles.title}
-              label={title}
-            />
-            <IconButton
-              style={styles.exitButton}
-              icon="cancel"
-              colour="#4f4f4f"
-              onPress={dismiss}
-            />
+            <PrimaryText size={30} weight={FontWeight.Bold} label={title} />
+            {dismiss && (
+              <IconButton
+                style={styles.exitButton}
+                icon="cancel"
+                colour="#4f4f4f"
+                onPress={dismiss}
+              />
+            )}
           </View>
           <View style={styles.content}>{children}</View>
         </View>

--- a/packages/TorneloScoresheet/src/components/Sheet/style.ts
+++ b/packages/TorneloScoresheet/src/components/Sheet/style.ts
@@ -27,11 +27,9 @@ export const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'space-between',
-  },
-  title: {
-    paddingLeft: 20,
+    padding: 20,
   },
   exitButton: {
-    padding: 20,
+    paddingLeft: 20,
   },
 });

--- a/packages/TorneloScoresheet/src/components/Toolbar/Toolbar.tsx
+++ b/packages/TorneloScoresheet/src/components/Toolbar/Toolbar.tsx
@@ -59,7 +59,7 @@ const Toolbar: React.FC = () => {
     [AppMode.EnterPgn]: voidReturn,
     [AppMode.GraphicalRecording]:
       useGraphicalRecordingState()?.[1].goToArbiterGameMode ?? voidReturn,
-    [AppMode.PariringSelection]: voidReturn,
+    [AppMode.PairingSelection]: voidReturn,
     [AppMode.ResultDisplay]:
       useResultDisplayState()?.[1].goToArbiterMode ?? voidReturn,
     [AppMode.TablePairing]:

--- a/packages/TorneloScoresheet/src/components/Toolbar/Toolbar.tsx
+++ b/packages/TorneloScoresheet/src/components/Toolbar/Toolbar.tsx
@@ -13,7 +13,7 @@ import {
   textColour,
 } from '../../style/colour';
 import { BLACK_LOGO_IMAGE, WHITE_LOGO_IMAGE } from '../../style/images';
-import { AppMode } from '../../types/AppModeState';
+import { AppMode, isArbiterMode } from '../../types/AppModeState';
 import IconButton from '../IconButton/IconButton';
 import PrimaryText, { FontWeight } from '../PrimaryText/PrimaryText';
 import Sheet from '../Sheet/Sheet';
@@ -27,27 +27,8 @@ import Pin from '../Pin/Pin';
  * as well as what actions and buttons are available
  */
 
-const colourForMode: Record<AppMode, ColourType> = {
-  [AppMode.EnterPgn]: colours.tertiary,
-  [AppMode.PariringSelection]: colours.tertiary,
-  [AppMode.ArbiterGraphicalRecording]: colours.tertiary,
-  [AppMode.ArbiterTablePairing]: colours.tertiary,
-  [AppMode.ArbiterResultDisplay]: colours.tertiary,
-  [AppMode.TablePairing]: colours.primary,
-  [AppMode.GraphicalRecording]: colours.primary,
-  [AppMode.ResultDisplay]: colours.primary,
-};
-
-const arbiterModeDisplay: Record<AppMode, boolean> = {
-  [AppMode.EnterPgn]: true,
-  [AppMode.PariringSelection]: true,
-  [AppMode.ArbiterGraphicalRecording]: true,
-  [AppMode.ArbiterTablePairing]: true,
-  [AppMode.TablePairing]: false,
-  [AppMode.GraphicalRecording]: false,
-  [AppMode.ResultDisplay]: false,
-  [AppMode.ArbiterResultDisplay]: true,
-};
+const colourForMode = (appMode: AppMode): ColourType =>
+  isArbiterMode(appMode) ? colours.tertiary : colours.primary;
 
 const backgroundColorStyle = (backgroundColor: string) => ({
   backgroundColor,
@@ -63,8 +44,8 @@ const Toolbar: React.FC = () => {
   const handleArbiterPress = () => {
     setShowArbiterSheet(a => !a);
   };
-  const currentColour = colourForMode[appModeState.mode];
-  const showArbiterModeButton = !arbiterModeDisplay[appModeState.mode];
+  const currentColour = colourForMode(appModeState.mode);
+  const showArbiterModeButton = !isArbiterMode(appModeState.mode);
   const currentTextColour = textColour(currentColour);
 
   const voidReturn: () => void = () => {

--- a/packages/TorneloScoresheet/src/context/AppModeStateContext.tsx
+++ b/packages/TorneloScoresheet/src/context/AppModeStateContext.tsx
@@ -32,11 +32,17 @@ export const AppModeStateContextProvider: React.FC = ({ children }) => {
 
 // state creations
 export const useEnterPgnState = makeUseEnterPgnState(AppModeStateContext);
+
 export const usePairingSelectionState =
   makeUsePairingSelectionState(AppModeStateContext);
+
 export const useTablePairingState =
   makeUseTablePairingState(AppModeStateContext);
+
 export const useGraphicalRecordingState =
   makeUseGraphicalRecordingState(AppModeStateContext);
+
 export const useResultDisplayState =
   makeUseResultDisplayState(AppModeStateContext);
+
+export const useCurrentAppMode = () => useContext(AppModeStateContext)[0].mode;

--- a/packages/TorneloScoresheet/src/context/ModalStackContext.tsx
+++ b/packages/TorneloScoresheet/src/context/ModalStackContext.tsx
@@ -1,0 +1,48 @@
+import React, { useContext, useEffect, useMemo, useState } from 'react';
+
+type ModalHook = {
+  shown: boolean;
+};
+
+// Global state for a stack of currently shown modals.
+// Unfortunately, React Native doesn't allow more than one
+// modal to be open at a time, so, we manage a stack of all
+// "open" modals, and only allow the top one to be shown
+const ModalStackContext = React.createContext<
+  [string[], React.Dispatch<React.SetStateAction<string[]>>]
+>([[], () => undefined]);
+
+// Custom hook to register yourself as a modal on the global
+// modal stack. The hook tells you whether you are currently
+// visible or not (i.e. whether you are the top of the stack)
+export const useModal = (id: string, visible: boolean): ModalHook => {
+  const [stack, setStack] = useContext(ModalStackContext);
+
+  useEffect(() => {
+    setStack(s => {
+      if (visible && s.indexOf(id) < 0) {
+        return [...s, id];
+      } else if (!visible && s.indexOf(id) >= 0) {
+        return s.filter(modalId => modalId !== id);
+      }
+      return s;
+    });
+  }, [visible, id, setStack]);
+
+  return {
+    shown: useMemo(
+      () => visible && stack[stack.length - 1] === id,
+      [stack, visible, id],
+    ),
+  };
+};
+
+export const ModalStackContextProvider: React.FC = ({ children }) => {
+  const modalStack = useState<string[]>([]);
+
+  return (
+    <ModalStackContext.Provider value={modalStack}>
+      {children}
+    </ModalStackContext.Provider>
+  );
+};

--- a/packages/TorneloScoresheet/src/hooks/appMode/enterPgnState.ts
+++ b/packages/TorneloScoresheet/src/hooks/appMode/enterPgnState.ts
@@ -68,7 +68,7 @@ const makegoToTablePairingSelection =
       .map(({ data }) => data);
 
     setAppMode({
-      mode: AppMode.PariringSelection,
+      mode: AppMode.PairingSelection,
       games: pairings.length,
       pairings,
     });

--- a/packages/TorneloScoresheet/src/hooks/appMode/pairingSelectionState.ts
+++ b/packages/TorneloScoresheet/src/hooks/appMode/pairingSelectionState.ts
@@ -23,7 +23,7 @@ export const makeUsePairingSelectionState =
   (): PairingSelectionStateHookType | null => {
     const [appModeState, setAppModeState] = useContext(context);
 
-    if (appModeState.mode !== AppMode.PariringSelection) {
+    if (appModeState.mode !== AppMode.PairingSelection) {
       return null;
     }
 

--- a/packages/TorneloScoresheet/src/pages/Main.tsx
+++ b/packages/TorneloScoresheet/src/pages/Main.tsx
@@ -14,7 +14,7 @@ const Main: React.FC = () => {
   switch (appMode.mode) {
     case AppMode.EnterPgn:
       return <EnterPgn />;
-    case AppMode.PariringSelection:
+    case AppMode.PairingSelection:
       return <PairingSelection />;
     case AppMode.TablePairing:
       return <TablePairing />;

--- a/packages/TorneloScoresheet/src/types/AppModeState.ts
+++ b/packages/TorneloScoresheet/src/types/AppModeState.ts
@@ -13,6 +13,18 @@ export enum AppMode {
   ArbiterResultDisplay,
 }
 
+export const isArbiterMode = (mode: AppMode): boolean =>
+  ({
+    [AppMode.EnterPgn]: true,
+    [AppMode.PariringSelection]: true,
+    [AppMode.TablePairing]: false,
+    [AppMode.GraphicalRecording]: false,
+    [AppMode.ResultDisplay]: false,
+    [AppMode.ArbiterGraphicalRecording]: true,
+    [AppMode.ArbiterTablePairing]: true,
+    [AppMode.ArbiterResultDisplay]: true,
+  }[mode]);
+
 export type EnterPgnMode = {
   mode: AppMode.EnterPgn;
 };

--- a/packages/TorneloScoresheet/src/types/AppModeState.ts
+++ b/packages/TorneloScoresheet/src/types/AppModeState.ts
@@ -4,7 +4,7 @@ import { ChessPly } from './ChessMove';
 
 export enum AppMode {
   EnterPgn,
-  PariringSelection,
+  PairingSelection,
   TablePairing,
   GraphicalRecording,
   ResultDisplay,
@@ -16,7 +16,7 @@ export enum AppMode {
 export const isArbiterMode = (mode: AppMode): boolean =>
   ({
     [AppMode.EnterPgn]: true,
-    [AppMode.PariringSelection]: true,
+    [AppMode.PairingSelection]: true,
     [AppMode.TablePairing]: false,
     [AppMode.GraphicalRecording]: false,
     [AppMode.ResultDisplay]: false,
@@ -29,7 +29,7 @@ export type EnterPgnMode = {
   mode: AppMode.EnterPgn;
 };
 export type PairingSelectionMode = {
-  mode: AppMode.PariringSelection;
+  mode: AppMode.PairingSelection;
   games?: number;
   pairings?: ChessGameInfo[];
 };


### PR DESCRIPTION
If the app is exited or moved to the background, we lock the app down

This PR also introduces the global modal stack context, to keep track of which modal to show. This is required because React Native only supports showing one modal at a time. We get around this by managing our own stack of modals with this new context.