### PR TITLE
Signature page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ buck-out/
 
 # VS Code
 /.vs/
+/-- verify/logs

--- a/packages/TorneloScoresheet/--verify/_logs/2022-07-26T02_00_44_640Z-debug-0.log
+++ b/packages/TorneloScoresheet/--verify/_logs/2022-07-26T02_00_44_640Z-debug-0.log
@@ -1,0 +1,36 @@
+0 verbose cli [
+0 verbose cli   'C:\\Program Files\\nodejs\\node.exe',
+0 verbose cli   'C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js',
+0 verbose cli   '--cache',
+0 verbose cli   '--verify'
+0 verbose cli ]
+1 info using npm@8.5.0
+2 info using node@v16.14.2
+3 timing npm:load:whichnode Completed in 0ms
+4 timing config:load:defaults Completed in 2ms
+5 timing config:load:file:C:\Program Files\nodejs\node_modules\npm\npmrc Completed in 2ms
+6 timing config:load:builtin Completed in 3ms
+7 timing config:load:cli Completed in 2ms
+8 timing config:load:env Completed in 0ms
+9 timing config:load:file:C:\Users\lliov\Documents\FIT4002\scoresheet-app\packages\TorneloScoresheet\.npmrc Completed in 1ms
+10 timing config:load:project Completed in 6ms
+11 timing config:load:file:C:\Users\lliov\.npmrc Completed in 0ms
+12 timing config:load:user Completed in 0ms
+13 timing config:load:file:C:\Users\lliov\AppData\Roaming\npm\etc\npmrc Completed in 1ms
+14 timing config:load:global Completed in 1ms
+15 timing config:load:validate Completed in 1ms
+16 timing config:load:credentials Completed in 0ms
+17 timing config:load:setEnvs Completed in 1ms
+18 timing config:load Completed in 16ms
+19 timing npm:load:configload Completed in 16ms
+20 timing npm:load:setTitle Completed in 1ms
+21 timing config:load:flatten Completed in 2ms
+22 timing npm:load:display Completed in 3ms
+23 verbose logfile C:\Users\lliov\Documents\FIT4002\scoresheet-app\packages\TorneloScoresheet\--verify\_logs\2022-07-26T02_00_44_640Z-debug-0.log
+24 timing npm:load:logFile Completed in 7ms
+25 timing npm:load:timers Completed in 0ms
+26 timing npm:load:configScope Completed in 0ms
+27 timing npm:load Completed in 27ms
+28 verbose exit 0
+29 timing npm Completed in 217ms
+30 verbose code 1

--- a/packages/TorneloScoresheet/__tests__/useAppModeState.test.ts
+++ b/packages/TorneloScoresheet/__tests__/useAppModeState.test.ts
@@ -967,7 +967,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
     const graphicalStateHook = renderCustomHook(useGraphicalRecordingState);
     const result = {
       winner: PlayerColour.White,
-      signature: ['base 64 image', 'base 64 image'],
+      signature: { 0: 'base 64 image', 1: 'base 64 image' },
       gamePgn: 'game pgn',
     };
 
@@ -1104,7 +1104,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
     const graphicalStateHook = renderCustomHook(useGraphicalRecordingState);
     const result = {
       winner: PlayerColour.Black,
-      signature: ['base 64 image', 'base 64 image'],
+      signature: { 0: 'base 64 image', 1: 'base 64 image' },
       gamePgn: 'game pgn',
     };
 
@@ -1241,7 +1241,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
     const graphicalStateHook = renderCustomHook(useGraphicalRecordingState);
     const result = {
       winner: null,
-      signature: ['base 64 image', 'base 64 image'],
+      signature: { 0: 'base 64 image', 1: 'base 64 image' },
       gamePgn: 'game pgn',
     };
 

--- a/packages/TorneloScoresheet/__tests__/useAppModeState.test.ts
+++ b/packages/TorneloScoresheet/__tests__/useAppModeState.test.ts
@@ -967,7 +967,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
     const graphicalStateHook = renderCustomHook(useGraphicalRecordingState);
     const result = {
       winner: PlayerColour.White,
-      signature: 'base 64 image',
+      signature: ['base 64 image', 'base 64 image'],
       gamePgn: 'game pgn',
     };
 
@@ -1104,7 +1104,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
     const graphicalStateHook = renderCustomHook(useGraphicalRecordingState);
     const result = {
       winner: PlayerColour.Black,
-      signature: 'base 64 image',
+      signature: ['base 64 image', 'base 64 image'],
       gamePgn: 'game pgn',
     };
 
@@ -1241,7 +1241,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
     const graphicalStateHook = renderCustomHook(useGraphicalRecordingState);
     const result = {
       winner: null,
-      signature: 'base 64 image',
+      signature: ['base 64 image', 'base 64 image'],
       gamePgn: 'game pgn',
     };
 

--- a/packages/TorneloScoresheet/src/components/Signature/Signature.tsx
+++ b/packages/TorneloScoresheet/src/components/Signature/Signature.tsx
@@ -4,6 +4,10 @@ import SignatureCapture, {
   SaveEventParams,
 } from 'react-native-signature-capture';
 import { colours } from '../../style/colour';
+import { Player } from '../../types/ChessGameInfo';
+import { PieceType } from '../../types/ChessMove';
+import { fullName } from '../../util/player';
+import PieceAsset from '../PieceAsset/PieceAsset';
 import PrimaryButton from '../PrimaryButton/PrimaryButton';
 import PrimaryText, { FontWeight } from '../PrimaryText/PrimaryText';
 import Sheet from '../Sheet/Sheet';
@@ -13,6 +17,8 @@ export type SignatureProps = {
   visible: boolean;
   onCancel: () => void;
   winnerName: string | null;
+  whitePlayer: Player;
+  blackPlayer: Player;
   onConfirm: (signature: string) => void;
 };
 
@@ -20,6 +26,8 @@ const Signature: React.FC<SignatureProps> = ({
   visible,
   onCancel,
   winnerName,
+  whitePlayer,
+  blackPlayer,
   onConfirm,
 }) => {
   const sign = useRef<any>();
@@ -29,27 +37,80 @@ const Signature: React.FC<SignatureProps> = ({
     onConfirm(base64Image);
   };
 
+  const resultText = (winnerName: string | null, playerName: string | null) => {
+    return winnerName === null ? 1 : playerName === winnerName ? 1 : 0;
+  };
+
   return (
     <>
       <Sheet dismiss={onCancel} visible={visible}>
         <PrimaryText
           style={styles.messageText}
           weight={FontWeight.Bold}
-          size={30}
+          size={40}
           colour={colours.darkenedElements}>
-          {`Sign to confirm ${
-            (winnerName && 'winner: ' + winnerName) ?? 'draw'
-          }`}
+          {'Confirm Result'}
         </PrimaryText>
-        <SignatureCapture
-          onSaveEvent={handleSaveSignature}
-          saveImageFileInExtStorage={false}
-          ref={sign}
-          style={styles.signature}
-          showNativeButtons={false}
-          showTitleLabel={false}
-          viewMode={'portrait'}
-        />
+        <View style={styles.resultArea}>
+          <PrimaryText
+            style={styles.resultText}
+            weight={FontWeight.Bold}
+            size={40}
+            colour={colours.darkenedElements}>
+            {`${fullName(whitePlayer)} \n `}
+            {`${resultText(winnerName, fullName(whitePlayer))}`}
+            <PieceAsset
+              piece={{ type: PieceType.King, player: whitePlayer.color }}
+              size={40}
+            />
+          </PrimaryText>
+          <PrimaryText
+            style={styles.resultText}
+            weight={FontWeight.Bold}
+            size={40}
+            colour={colours.darkenedElements}>
+            {`${fullName(blackPlayer)} \n`}
+            <PieceAsset
+              piece={{ type: PieceType.King, player: blackPlayer.color }}
+              size={40}
+            />
+            {`${resultText(winnerName, fullName(blackPlayer))}`}
+          </PrimaryText>
+        </View>
+        <View style={styles.signatureArea}>
+          <PrimaryText
+            style={styles.messageText}
+            weight={FontWeight.Bold}
+            size={30}
+            colour={colours.darkenedElements}>
+            {`Signature of ${fullName(whitePlayer)}`}
+          </PrimaryText>
+          <SignatureCapture
+            onSaveEvent={handleSaveSignature}
+            saveImageFileInExtStorage={false}
+            ref={sign}
+            style={styles.signature}
+            showNativeButtons={false}
+            showTitleLabel={false}
+            viewMode={'portrait'}
+          />
+          <PrimaryText
+            style={styles.messageText}
+            weight={FontWeight.Bold}
+            size={30}
+            colour={colours.darkenedElements}>
+            {`Signature of ${fullName(blackPlayer)}`}
+          </PrimaryText>
+          <SignatureCapture
+            onSaveEvent={handleSaveSignature}
+            saveImageFileInExtStorage={false}
+            ref={sign}
+            style={styles.signature}
+            showNativeButtons={false}
+            showTitleLabel={false}
+            viewMode={'portrait'}
+          />
+        </View>
         <View style={styles.buttonArea}>
           <PrimaryButton
             style={styles.buttonStyle}

--- a/packages/TorneloScoresheet/src/components/Signature/Signature.tsx
+++ b/packages/TorneloScoresheet/src/components/Signature/Signature.tsx
@@ -4,7 +4,7 @@ import SignatureCapture, {
   SaveEventParams,
 } from 'react-native-signature-capture';
 import { colours } from '../../style/colour';
-import { Player, PlayerColour } from '../../types/ChessGameInfo';
+import { Player } from '../../types/ChessGameInfo';
 import { PieceType } from '../../types/ChessMove';
 import { fullName } from '../../util/player';
 import PieceAsset from '../PieceAsset/PieceAsset';
@@ -41,10 +41,6 @@ const Signature: React.FC<SignatureProps> = ({
 
   const resultText = (winnerName: string | null, playerName: string | null) => {
     return winnerName === null ? 1 : playerName === winnerName ? 1 : 0;
-  };
-
-  const playerName = (currentPlayer: PlayerColour) => {
-    return currentPlayer === white.color ? fullName(white) : fullName(black);
   };
 
   return (

--- a/packages/TorneloScoresheet/src/components/Signature/Signature.tsx
+++ b/packages/TorneloScoresheet/src/components/Signature/Signature.tsx
@@ -17,8 +17,9 @@ export type SignatureProps = {
   visible: boolean;
   onCancel: () => void;
   winnerName: string | null;
-  whitePlayer: Player;
-  blackPlayer: Player;
+  white: Player;
+  black: Player;
+  currentPlayer: Player;
   onConfirm: (signature: string) => void;
 };
 
@@ -26,8 +27,9 @@ const Signature: React.FC<SignatureProps> = ({
   visible,
   onCancel,
   winnerName,
-  whitePlayer,
-  blackPlayer,
+  white: white,
+  black: black,
+  currentPlayer: player,
   onConfirm,
 }) => {
   const sign = useRef<any>();
@@ -57,10 +59,10 @@ const Signature: React.FC<SignatureProps> = ({
             weight={FontWeight.Bold}
             size={40}
             colour={colours.darkenedElements}>
-            {`${fullName(whitePlayer)} \n `}
-            {`${resultText(winnerName, fullName(whitePlayer))}`}
+            {`${fullName(white)} \n `}
+            {`${resultText(winnerName, fullName(white))}`}
             <PieceAsset
-              piece={{ type: PieceType.King, player: whitePlayer.color }}
+              piece={{ type: PieceType.King, player: white.color }}
               size={40}
             />
           </PrimaryText>
@@ -69,12 +71,12 @@ const Signature: React.FC<SignatureProps> = ({
             weight={FontWeight.Bold}
             size={40}
             colour={colours.darkenedElements}>
-            {`${fullName(blackPlayer)} \n`}
+            {`${fullName(black)} \n`}
             <PieceAsset
-              piece={{ type: PieceType.King, player: blackPlayer.color }}
+              piece={{ type: PieceType.King, player: black.color }}
               size={40}
             />
-            {`${resultText(winnerName, fullName(blackPlayer))}`}
+            {`${resultText(winnerName, fullName(black))}`}
           </PrimaryText>
         </View>
         <View style={styles.signatureArea}>
@@ -83,23 +85,7 @@ const Signature: React.FC<SignatureProps> = ({
             weight={FontWeight.Bold}
             size={30}
             colour={colours.darkenedElements}>
-            {`Signature of ${fullName(whitePlayer)}`}
-          </PrimaryText>
-          <SignatureCapture
-            onSaveEvent={handleSaveSignature}
-            saveImageFileInExtStorage={false}
-            ref={sign}
-            style={styles.signature}
-            showNativeButtons={false}
-            showTitleLabel={false}
-            viewMode={'portrait'}
-          />
-          <PrimaryText
-            style={styles.messageText}
-            weight={FontWeight.Bold}
-            size={30}
-            colour={colours.darkenedElements}>
-            {`Signature of ${fullName(blackPlayer)}`}
+            {`Signature of ${fullName(player)}`}
           </PrimaryText>
           <SignatureCapture
             onSaveEvent={handleSaveSignature}

--- a/packages/TorneloScoresheet/src/components/Signature/Signature.tsx
+++ b/packages/TorneloScoresheet/src/components/Signature/Signature.tsx
@@ -4,7 +4,7 @@ import SignatureCapture, {
   SaveEventParams,
 } from 'react-native-signature-capture';
 import { colours } from '../../style/colour';
-import { Player } from '../../types/ChessGameInfo';
+import { Player, PlayerColour } from '../../types/ChessGameInfo';
 import { PieceType } from '../../types/ChessMove';
 import { fullName } from '../../util/player';
 import PieceAsset from '../PieceAsset/PieceAsset';
@@ -19,7 +19,7 @@ export type SignatureProps = {
   winnerName: string | null;
   white: Player;
   black: Player;
-  currentPlayer: Player;
+  currentPlayer: string;
   onConfirm: (signature: string) => void;
 };
 
@@ -41,6 +41,10 @@ const Signature: React.FC<SignatureProps> = ({
 
   const resultText = (winnerName: string | null, playerName: string | null) => {
     return winnerName === null ? 1 : playerName === winnerName ? 1 : 0;
+  };
+
+  const playerName = (currentPlayer: PlayerColour) => {
+    return currentPlayer === white.color ? fullName(white) : fullName(black);
   };
 
   return (
@@ -85,7 +89,7 @@ const Signature: React.FC<SignatureProps> = ({
             weight={FontWeight.Bold}
             size={30}
             colour={colours.darkenedElements}>
-            {`Signature of ${fullName(player)}`}
+            {`Signature of ${player}`}
           </PrimaryText>
           <SignatureCapture
             onSaveEvent={handleSaveSignature}

--- a/packages/TorneloScoresheet/src/components/Signature/Signature.tsx
+++ b/packages/TorneloScoresheet/src/components/Signature/Signature.tsx
@@ -36,6 +36,7 @@ const Signature: React.FC<SignatureProps> = ({
 
   const handleSaveSignature = async (event: SaveEventParams) => {
     const base64Image = `data:image/png;base64,${event.encoded}`;
+    sign.current.resetImage();
     onConfirm(base64Image);
   };
 

--- a/packages/TorneloScoresheet/src/components/Signature/style.ts
+++ b/packages/TorneloScoresheet/src/components/Signature/style.ts
@@ -4,7 +4,7 @@ import { colours } from '../../style/colour';
 export const styles = StyleSheet.create({
   signature: {
     width: '100%',
-    height: 400,
+    height: 150,
   },
 
   buttonStyle: {
@@ -22,5 +22,24 @@ export const styles = StyleSheet.create({
   messageText: {
     textAlign: 'center',
     minWidth: 500,
+  },
+
+  resultText: {
+    textAlign: 'center',
+    minWidth: 500,
+    marginTop: 25,
+  },
+
+  signatureArea: {
+    marginTop: 15,
+  },
+
+  resultArea: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+    height: 150,
+    marginTop: 10,
+    backgroundColor: colours.primary20,
+    borderRadius: 20,
   },
 });

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
@@ -52,11 +52,13 @@ const GraphicalRecording: React.FC = () => {
   const [pgn, setPgn] = useState('');
   const [, showError] = useError();
   const [showEndGame, setShowEndGame] = useState(false);
-  const [showSignature, setShowSignature] = useState(false);
+  const [showFirstSignature, setShowFirstSignature] = useState(false);
+  const [showSecondSignature, setShowSecondSignature] = useState(false);
   const goToEndGame = graphicalRecordingState?.[1].goToEndGame;
   const [selectedWinner, setSelectedWinner] = useState<
     undefined | Player | null
   >(undefined);
+  const [playerSignatures, setPlayerSignatures] = useState<string[]>([]);
 
   // Scroll view ref
   const scrollRef = useRef<ScrollView>(null);
@@ -171,16 +173,30 @@ const GraphicalRecording: React.FC = () => {
     : [];
 
   // Button Functions
-  const handleConfirmWinner = (signature: string) => {
+
+  const handleConfirmWinner = (signatureInput: string) => {
+    const signatureArray = [...playerSignatures, signatureInput];
     if (!graphicalRecordingMode || !goToEndGame) {
       return;
     } else {
-      goToEndGame({
-        winner: selectedWinner?.color ?? null,
-        signature: signature,
-        gamePgn: pgn,
-      });
+      if (signatureArray.length == 2) {
+        setPlayerSignatures(() => []);
+        goToEndGame({
+          winner: selectedWinner?.color ?? null,
+          signature: signatureArray,
+          gamePgn: pgn,
+        });
+      }
     }
+  };
+
+  const handleConfirmFirstSignature = (signatureInput: string) => {
+    setPlayerSignatures(playerSignatures => [
+      ...playerSignatures,
+      signatureInput,
+    ]);
+    setShowFirstSignature(false);
+    setShowSecondSignature(true);
   };
 
   const handleSelectWinner = (player: Player | null) => {
@@ -197,13 +213,14 @@ const GraphicalRecording: React.FC = () => {
     setPgn(pgnResult.data);
 
     // if pgn can be generated -> prompt user for signature
-    setShowSignature(true);
+    setShowFirstSignature(true);
     setShowEndGame(false);
     setSelectedWinner(player);
   };
 
   const handleCancelSelection = () => {
-    setShowSignature(false);
+    setShowFirstSignature(false);
+    setShowSecondSignature(false);
     setShowEndGame(false);
     setSelectedWinner(undefined);
   };
@@ -287,12 +304,22 @@ const GraphicalRecording: React.FC = () => {
             onCancel={handleCancelSelection}
           />
           <Signature
-            visible={showSignature}
+            visible={showFirstSignature}
+            onCancel={handleCancelSelection}
+            winnerName={(selectedWinner && fullName(selectedWinner)) ?? null}
+            onConfirm={handleConfirmFirstSignature}
+            white={graphicalRecordingMode.pairing.players[0]}
+            black={graphicalRecordingMode.pairing.players[1]}
+            currentPlayer={graphicalRecordingMode.pairing.players[0]}
+          />
+          <Signature
+            visible={showSecondSignature}
             onCancel={handleCancelSelection}
             winnerName={(selectedWinner && fullName(selectedWinner)) ?? null}
             onConfirm={handleConfirmWinner}
-            whitePlayer={graphicalRecordingMode.pairing.players[0]}
-            blackPlayer={graphicalRecordingMode.pairing.players[1]}
+            white={graphicalRecordingMode.pairing.players[0]}
+            black={graphicalRecordingMode.pairing.players[1]}
+            currentPlayer={graphicalRecordingMode.pairing.players[1]}
           />
           {/*----- body ----- */}
           <View style={styles.placeholder}>

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
@@ -291,6 +291,8 @@ const GraphicalRecording: React.FC = () => {
             onCancel={handleCancelSelection}
             winnerName={(selectedWinner && fullName(selectedWinner)) ?? null}
             onConfirm={handleConfirmWinner}
+            whitePlayer={graphicalRecordingMode.pairing.players[0]}
+            blackPlayer={graphicalRecordingMode.pairing.players[1]}
           />
           {/*----- body ----- */}
           <View style={styles.placeholder}>

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
@@ -310,7 +310,11 @@ const GraphicalRecording: React.FC = () => {
             onConfirm={handleConfirmFirstSignature}
             white={graphicalRecordingMode.pairing.players[0]}
             black={graphicalRecordingMode.pairing.players[1]}
-            currentPlayer={graphicalRecordingMode.pairing.players[0]}
+            currentPlayer={
+              graphicalRecordingMode.currentPlayer === PlayerColour.White
+                ? fullName(graphicalRecordingMode.pairing.players[0])
+                : fullName(graphicalRecordingMode.pairing.players[1])
+            }
           />
           <Signature
             visible={showSecondSignature}
@@ -319,7 +323,11 @@ const GraphicalRecording: React.FC = () => {
             onConfirm={handleConfirmWinner}
             white={graphicalRecordingMode.pairing.players[0]}
             black={graphicalRecordingMode.pairing.players[1]}
-            currentPlayer={graphicalRecordingMode.pairing.players[1]}
+            currentPlayer={
+              graphicalRecordingMode.currentPlayer === PlayerColour.White
+                ? fullName(graphicalRecordingMode.pairing.players[1])
+                : fullName(graphicalRecordingMode.pairing.players[0])
+            }
           />
           {/*----- body ----- */}
           <View style={styles.placeholder}>

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
@@ -52,14 +52,14 @@ const GraphicalRecording: React.FC = () => {
   const [pgn, setPgn] = useState('');
   const [, showError] = useError();
   const [showEndGame, setShowEndGame] = useState(false);
-  const [showSignature, setShowFirstSignature] = useState(false);
+  const [showSignature, setShowSignature] = useState(false);
   const goToEndGame = graphicalRecordingState?.[1].goToEndGame;
   const [selectedWinner, setSelectedWinner] = useState<
     undefined | Player | null
   >(undefined);
   const signatureFromPlayer: Record<PlayerColour, string | undefined> = {
-    [PlayerColour.Black]: undefined,
     [PlayerColour.White]: undefined,
+    [PlayerColour.Black]: undefined,
   };
   const [playerSignatures, setPlayerSignatures] =
     useState<Record<PlayerColour, string | undefined>>(signatureFromPlayer);
@@ -199,14 +199,16 @@ const GraphicalRecording: React.FC = () => {
         : (signatureRecord[0] = signatureInput);
 
       setPlayerSignatures(signatureRecord);
-      console.log(signatureRecord);
       if (signatureRecord[0] && signatureRecord[1]) {
         //resetting the signature state to empty values
         setPlayerSignatures(signatureFromPlayer);
         setSigningPlayer(graphicalRecordingMode?.currentPlayer);
         goToEndGame({
           winner: selectedWinner?.color ?? null,
-          signature: signatureRecord,
+          signature: {
+            [PlayerColour.White]: signatureRecord[PlayerColour.White] ?? '',
+            [PlayerColour.Black]: signatureRecord[PlayerColour.Black] ?? '',
+          },
           gamePgn: pgn,
         });
       }
@@ -227,13 +229,13 @@ const GraphicalRecording: React.FC = () => {
     setPgn(pgnResult.data);
 
     // if pgn can be generated -> prompt user for signature
-    setShowFirstSignature(true);
+    setShowSignature(true);
     setShowEndGame(false);
     setSelectedWinner(player);
   };
 
   const handleCancelSelection = () => {
-    setShowFirstSignature(false);
+    setShowSignature(false);
     setShowEndGame(false);
     setSelectedWinner(undefined);
     setPlayerSignatures(signatureFromPlayer);

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
@@ -52,13 +52,20 @@ const GraphicalRecording: React.FC = () => {
   const [pgn, setPgn] = useState('');
   const [, showError] = useError();
   const [showEndGame, setShowEndGame] = useState(false);
-  const [showFirstSignature, setShowFirstSignature] = useState(false);
-  const [showSecondSignature, setShowSecondSignature] = useState(false);
+  const [showSignature, setShowFirstSignature] = useState(false);
   const goToEndGame = graphicalRecordingState?.[1].goToEndGame;
   const [selectedWinner, setSelectedWinner] = useState<
     undefined | Player | null
   >(undefined);
-  const [playerSignatures, setPlayerSignatures] = useState<string[]>([]);
+  const signatureFromPlayer: Record<PlayerColour, string | undefined> = {
+    [PlayerColour.Black]: undefined,
+    [PlayerColour.White]: undefined,
+  };
+  const [playerSignatures, setPlayerSignatures] =
+    useState<Record<PlayerColour, string | undefined>>(signatureFromPlayer);
+  const [signingPlayer, setSigningPlayer] = useState(
+    graphicalRecordingMode?.currentPlayer,
+  );
 
   // Scroll view ref
   const scrollRef = useRef<ScrollView>(null);
@@ -175,28 +182,35 @@ const GraphicalRecording: React.FC = () => {
   // Button Functions
 
   const handleConfirmWinner = (signatureInput: string) => {
-    const signatureArray = [...playerSignatures, signatureInput];
     if (!graphicalRecordingMode || !goToEndGame) {
       return;
     } else {
-      if (signatureArray.length == 2) {
-        setPlayerSignatures(() => []);
+      signingPlayer == PlayerColour.White
+        ? setSigningPlayer(PlayerColour.Black)
+        : setSigningPlayer(PlayerColour.White);
+      const signatureRecord = { ...playerSignatures };
+      // if the current player is player 1 update the 0th index first, otherwise update index 1
+      graphicalRecordingMode.currentPlayer == PlayerColour.White
+        ? !signatureRecord[0]
+          ? (signatureRecord[0] = signatureInput)
+          : (signatureRecord[1] = signatureInput)
+        : !signatureRecord[1]
+        ? (signatureRecord[1] = signatureInput)
+        : (signatureRecord[0] = signatureInput);
+
+      setPlayerSignatures(signatureRecord);
+      console.log(signatureRecord);
+      if (signatureRecord[0] && signatureRecord[1]) {
+        //resetting the signature state to empty values
+        setPlayerSignatures(signatureFromPlayer);
+        setSigningPlayer(graphicalRecordingMode?.currentPlayer);
         goToEndGame({
           winner: selectedWinner?.color ?? null,
-          signature: signatureArray,
+          signature: signatureRecord,
           gamePgn: pgn,
         });
       }
     }
-  };
-
-  const handleConfirmFirstSignature = (signatureInput: string) => {
-    setPlayerSignatures(playerSignatures => [
-      ...playerSignatures,
-      signatureInput,
-    ]);
-    setShowFirstSignature(false);
-    setShowSecondSignature(true);
   };
 
   const handleSelectWinner = (player: Player | null) => {
@@ -220,10 +234,10 @@ const GraphicalRecording: React.FC = () => {
 
   const handleCancelSelection = () => {
     setShowFirstSignature(false);
-    setShowSecondSignature(false);
     setShowEndGame(false);
     setSelectedWinner(undefined);
-    setPlayerSignatures(() => []);
+    setPlayerSignatures(signatureFromPlayer);
+    setSigningPlayer(graphicalRecordingMode?.currentPlayer);
   };
 
   const handleToggleDraw = (drawIndex: number) => {
@@ -305,29 +319,16 @@ const GraphicalRecording: React.FC = () => {
             onCancel={handleCancelSelection}
           />
           <Signature
-            visible={showFirstSignature}
-            onCancel={handleCancelSelection}
-            winnerName={(selectedWinner && fullName(selectedWinner)) ?? null}
-            onConfirm={handleConfirmFirstSignature}
-            white={graphicalRecordingMode.pairing.players[0]}
-            black={graphicalRecordingMode.pairing.players[1]}
-            currentPlayer={
-              graphicalRecordingMode.currentPlayer === PlayerColour.White
-                ? fullName(graphicalRecordingMode.pairing.players[0])
-                : fullName(graphicalRecordingMode.pairing.players[1])
-            }
-          />
-          <Signature
-            visible={showSecondSignature}
+            visible={showSignature}
             onCancel={handleCancelSelection}
             winnerName={(selectedWinner && fullName(selectedWinner)) ?? null}
             onConfirm={handleConfirmWinner}
             white={graphicalRecordingMode.pairing.players[0]}
             black={graphicalRecordingMode.pairing.players[1]}
             currentPlayer={
-              graphicalRecordingMode.currentPlayer === PlayerColour.White
-                ? fullName(graphicalRecordingMode.pairing.players[1])
-                : fullName(graphicalRecordingMode.pairing.players[0])
+              signingPlayer === PlayerColour.White
+                ? fullName(graphicalRecordingMode.pairing.players[0])
+                : fullName(graphicalRecordingMode.pairing.players[1])
             }
           />
           {/*----- body ----- */}

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
@@ -223,6 +223,7 @@ const GraphicalRecording: React.FC = () => {
     setShowSecondSignature(false);
     setShowEndGame(false);
     setSelectedWinner(undefined);
+    setPlayerSignatures(() => []);
   };
 
   const handleToggleDraw = (drawIndex: number) => {

--- a/packages/TorneloScoresheet/src/types/ChessGameInfo.ts
+++ b/packages/TorneloScoresheet/src/types/ChessGameInfo.ts
@@ -15,7 +15,7 @@ export type ChessGameInfo = {
 export type ChessGameResult = {
   winner: PlayerColour | null;
   gamePgn?: string;
-  signature: { 0: string | undefined; 1: string | undefined };
+  signature: Record<PlayerColour, string>;
 };
 
 export enum PlayerColour {

--- a/packages/TorneloScoresheet/src/types/ChessGameInfo.ts
+++ b/packages/TorneloScoresheet/src/types/ChessGameInfo.ts
@@ -15,7 +15,7 @@ export type ChessGameInfo = {
 export type ChessGameResult = {
   winner: PlayerColour | null;
   gamePgn?: string;
-  signature: string[];
+  signature: { 0: string | undefined; 1: string | undefined };
 };
 
 export enum PlayerColour {

--- a/packages/TorneloScoresheet/src/types/ChessGameInfo.ts
+++ b/packages/TorneloScoresheet/src/types/ChessGameInfo.ts
@@ -15,7 +15,7 @@ export type ChessGameInfo = {
 export type ChessGameResult = {
   winner: PlayerColour | null;
   gamePgn?: string;
-  signature: string;
+  signature: string[];
 };
 
 export enum PlayerColour {

--- a/packages/chess.ts/yarn.lock
+++ b/packages/chess.ts/yarn.lock
@@ -1805,11 +1805,6 @@
   "resolved" "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   "version" "1.0.0"
 
-"fsevents@^2.1.2":
-  "integrity" "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="
-  "resolved" "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
-  "version" "2.3.2"
-
 "function-bind@^1.1.1":
   "integrity" "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
   "resolved" "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"


### PR DESCRIPTION
Implemented signatures from both players. I chose to do them one at a time for the following reasons:
- it prevents one player from accidentally signing the wrong area
- it stops a player from accidentally editing the signature of the other player
- the UI looks less cluttered
- I tried a version with both signatures on the same popup but I didn't have room to fit two different confirm and reset buttons so if one player wanted to re-do their signature they both would have had to.

Also happy to take any suggestions to improve the design

https://user-images.githubusercontent.com/64511606/181193329-06c75552-1ca1-4697-b312-b25b81f76237.mp4


