### PR TITLE
Adding time to moves

### DIFF
--- a/packages/TorneloScoresheet/__tests__/useAppModeState.test.ts
+++ b/packages/TorneloScoresheet/__tests__/useAppModeState.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../testUtils/testUtils';
 import {
   ChessPly,
+  GameTime,
   MoveSquares,
   PieceType,
   PlyTypes,
@@ -1427,6 +1428,143 @@ describe('Toggle Draw Offer', () => {
               'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
             move: { from: 'a1', to: 'a5' } as MoveSquares,
             drawOffer: false,
+          },
+          {
+            moveNo: 1,
+            player: PlayerColour.Black,
+            startingFen:
+              'rnbqkbnr/pppppppp/8/R7/8/8/PPPPPPPP/1NBQKBNR b Kkq - 1 1',
+            move: { from: 'h8', to: 'h5' } as MoveSquares,
+            type: PlyTypes.MovePly,
+            drawOffer: false,
+          },
+        ],
+      });
+    });
+  });
+});
+
+describe('Add Game time', () => {
+  test('Add game time on move with no existing game time', () => {
+    const moveHistory = [
+      {
+        moveNo: 1,
+        player: PlayerColour.White,
+        startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+        type: PlyTypes.MovePly,
+        move: { from: 'a1', to: 'a5' } as MoveSquares,
+        drawOffer: false,
+      },
+    ];
+    const graphicalState = generateGraphicalRecordingState(moveHistory);
+    const setContextMock = mockAppModeContext(graphicalState);
+    const graphicalStateHook = renderCustomHook(useGraphicalRecordingState);
+
+    const gameTime: GameTime = { hours: 1, minutes: 1 };
+
+    act(() => {
+      ``;
+      graphicalStateHook.current?.[1].setGameTime(0, gameTime);
+      expect(setContextMock).toHaveBeenCalledTimes(1);
+      expect(typeof setContextMock.mock.calls[0][0]).toBe('function');
+      expect(setContextMock.mock.calls[0][0](graphicalState)).toEqual({
+        ...graphicalState,
+        moveHistory: [
+          {
+            moveNo: 1,
+            player: PlayerColour.White,
+            startingFen:
+              'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+            type: PlyTypes.MovePly,
+            move: { from: 'a1', to: 'a5' } as MoveSquares,
+            drawOffer: false,
+            gameTime,
+          },
+        ],
+      });
+    });
+  });
+
+  test('rfemove game time on move with existing game time', () => {
+    const moveHistory = [
+      {
+        moveNo: 1,
+        player: PlayerColour.White,
+        startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+        type: PlyTypes.MovePly,
+        move: { from: 'a1', to: 'a5' } as MoveSquares,
+        drawOffer: true,
+        gameTime: { hours: 1, minutes: 1 },
+      },
+    ];
+    const graphicalState = generateGraphicalRecordingState(moveHistory);
+    const setContextMock = mockAppModeContext(graphicalState);
+    const graphicalStateHook = renderCustomHook(useGraphicalRecordingState);
+
+    act(() => {
+      graphicalStateHook.current?.[1].setGameTime(0, undefined);
+      expect(setContextMock).toHaveBeenCalledTimes(1);
+      expect(typeof setContextMock.mock.calls[0][0]).toBe('function');
+      expect(setContextMock.mock.calls[0][0](graphicalState)).toEqual({
+        ...graphicalState,
+        moveHistory: [
+          {
+            moveNo: 1,
+            player: PlayerColour.White,
+            startingFen:
+              'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+            type: PlyTypes.MovePly,
+            move: { from: 'a1', to: 'a5' } as MoveSquares,
+            drawOffer: true,
+          },
+        ],
+      });
+    });
+  });
+
+  test('update game time to different time', () => {
+    const moveHistory = [
+      {
+        moveNo: 1,
+        player: PlayerColour.White,
+        type: PlyTypes.MovePly,
+        startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+        move: { from: 'a1', to: 'a5' } as MoveSquares,
+        drawOffer: false,
+        gameTime: { hours: 1, minutes: 1 },
+      },
+      {
+        moveNo: 1,
+        player: PlayerColour.Black,
+        startingFen: 'rnbqkbnr/pppppppp/8/R7/8/8/PPPPPPPP/1NBQKBNR b Kkq - 1 1',
+        move: { from: 'h8', to: 'h5' } as MoveSquares,
+        type: PlyTypes.MovePly,
+        drawOffer: false,
+      },
+    ];
+    const graphicalState = generateGraphicalRecordingState(moveHistory);
+    const setContextMock = mockAppModeContext(graphicalState);
+    const graphicalStateHook = renderCustomHook(useGraphicalRecordingState);
+    const newGameTime = { hours: 2, minutes: 2 };
+    act(() => {
+      graphicalStateHook.current?.[1].setGameTime(0, newGameTime);
+      expect(setContextMock).toHaveBeenCalledTimes(1);
+      expect(typeof setContextMock.mock.calls[0][0]).toBe('function');
+      expect(setContextMock.mock.calls[0][0](graphicalState)).toEqual({
+        ...graphicalState,
+        board: chessEngine.fenToBoardPositions(
+          'rnbqkbnr/pppppppp/8/R7/8/8/PPPPPPPP/1NBQKBNR b Kkq - 1 1',
+        ),
+        moveHistory: [
+          {
+            moveNo: 1,
+            player: PlayerColour.White,
+            type: PlyTypes.MovePly,
+            startingFen:
+              'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+            move: { from: 'a1', to: 'a5' } as MoveSquares,
+            drawOffer: false,
+            gameTime: newGameTime,
           },
           {
             moveNo: 1,

--- a/packages/TorneloScoresheet/ios/Podfile.lock
+++ b/packages/TorneloScoresheet/ios/Podfile.lock
@@ -282,6 +282,8 @@ PODS:
   - React-jsinspector (0.68.1)
   - React-logger (0.68.1):
     - glog
+  - react-native-date-picker (4.2.5):
+    - React-Core
   - react-native-signature-capture (0.4.12):
     - React
   - React-perflogger (0.68.1)
@@ -430,6 +432,7 @@ DEPENDENCIES:
   - React-jsiexecutor (from `../node_modules/react-native/ReactCommon/jsiexecutor`)
   - React-jsinspector (from `../node_modules/react-native/ReactCommon/jsinspector`)
   - React-logger (from `../node_modules/react-native/ReactCommon/logger`)
+  - react-native-date-picker (from `../node_modules/react-native-date-picker`)
   - react-native-signature-capture (from `../node_modules/react-native-signature-capture`)
   - React-perflogger (from `../node_modules/react-native/ReactCommon/reactperflogger`)
   - React-RCTActionSheet (from `../node_modules/react-native/Libraries/ActionSheetIOS`)
@@ -504,6 +507,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/jsinspector"
   React-logger:
     :path: "../node_modules/react-native/ReactCommon/logger"
+  react-native-date-picker:
+    :path: "../node_modules/react-native-date-picker"
   react-native-signature-capture:
     :path: "../node_modules/react-native-signature-capture"
   React-perflogger:
@@ -573,6 +578,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 4a4bae5671b064a2248a690cf75957669489d08c
   React-jsinspector: 218a2503198ff28a085f8e16622a8d8f507c8019
   React-logger: f79dd3cc0f9b44f5611c6c7862badd891a862cf8
+  react-native-date-picker: 55193347d8d0f40948f441ffd4e5db6f0a8fbe13
   react-native-signature-capture: 416a3947684e049a5b012cdd6496f878dc797f16
   React-perflogger: 30ab8d6db10e175626069e742eead3ebe8f24fd5
   React-RCTActionSheet: 4b45da334a175b24dabe75f856b98fed3dfd6201

--- a/packages/TorneloScoresheet/package-lock.json
+++ b/packages/TorneloScoresheet/package-lock.json
@@ -15,6 +15,7 @@
         "react": "17.0.2",
         "react-native": "0.68.1",
         "react-native-confirmation-code-field": "^7.3.0",
+        "react-native-date-picker": "^4.2.5",
         "react-native-gesture-handler": "^2.4.2",
         "react-native-reanimated": "^2.8.0",
         "react-native-signature-capture": "^0.4.12",
@@ -19208,6 +19209,14 @@
         }
       }
     },
+    "node_modules/react-native-date-picker": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/react-native-date-picker/-/react-native-date-picker-4.2.5.tgz",
+      "integrity": "sha512-YjwiMpZEnVVS+ymLvmJDicVZ3pSR+nJHgtAhctMl6fO8f7iRNcYhY427gemlTBf2Ji+XIAK0Agyl255DhaemFw==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      }
+    },
     "node_modules/react-native-dotenv": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/react-native-dotenv/-/react-native-dotenv-3.3.1.tgz",
@@ -35568,6 +35577,14 @@
       "resolved": "https://registry.npmjs.org/react-native-confirmation-code-field/-/react-native-confirmation-code-field-7.3.0.tgz",
       "integrity": "sha512-o/ByEXh0+9aEehboH/MJorlwELDWpsViedf6Putogsxx2493dzFsZ9P/R9m3qZJ6s2AnWWL9Ja4qjzO9WE5zVg==",
       "requires": {}
+    },
+    "react-native-date-picker": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/react-native-date-picker/-/react-native-date-picker-4.2.5.tgz",
+      "integrity": "sha512-YjwiMpZEnVVS+ymLvmJDicVZ3pSR+nJHgtAhctMl6fO8f7iRNcYhY427gemlTBf2Ji+XIAK0Agyl255DhaemFw==",
+      "requires": {
+        "prop-types": "^15.8.1"
+      }
     },
     "react-native-dotenv": {
       "version": "3.3.1",

--- a/packages/TorneloScoresheet/package.json
+++ b/packages/TorneloScoresheet/package.json
@@ -17,6 +17,7 @@
     "react": "17.0.2",
     "react-native": "0.68.1",
     "react-native-confirmation-code-field": "^7.3.0",
+    "react-native-date-picker": "^4.2.5",
     "react-native-gesture-handler": "^2.4.2",
     "react-native-reanimated": "^2.8.0",
     "react-native-signature-capture": "^0.4.12",

--- a/packages/TorneloScoresheet/src/components/MoveCard/MoveCard.tsx
+++ b/packages/TorneloScoresheet/src/components/MoveCard/MoveCard.tsx
@@ -25,6 +25,7 @@ const MoveCard: React.FC<MoveCardProps> = ({ move, onRequestEditMove }) => {
           style={styles.touchableOpacity}
           onLongPress={() => onRequestEditMove(PlayerColour.White)}>
           {move.white.drawOffer && <DrawOfferIcon />}
+          {move.white.gameTime && <GameTimeIcon />}
           <PrimaryText size={18} align={Align.Center} weight={FontWeight.Bold}>
             {moveString(move.white)}
           </PrimaryText>
@@ -42,6 +43,7 @@ const MoveCard: React.FC<MoveCardProps> = ({ move, onRequestEditMove }) => {
           disabled={!move.black}
           onLongPress={() => onRequestEditMove(PlayerColour.Black)}>
           {move.black?.drawOffer && <DrawOfferIcon />}
+          {move.black?.gameTime && <GameTimeIcon />}
           <PrimaryText size={18} align={Align.Center} weight={FontWeight.Bold}>
             {move.black ? moveString(move.black) : ' '}
           </PrimaryText>
@@ -84,6 +86,16 @@ const DrawOfferIcon = () => {
         size={size}
         color={colours.darkGrey}
       />
+      <View style={iconBackground(size)} />
+    </View>
+  );
+};
+
+const GameTimeIcon = () => {
+  const size = 16;
+  return (
+    <View style={styles.gameTimeIconContainer}>
+      <Icon name="clock" size={size} color={colours.darkGrey} />
       <View style={iconBackground(size)} />
     </View>
   );

--- a/packages/TorneloScoresheet/src/components/MoveCard/style.ts
+++ b/packages/TorneloScoresheet/src/components/MoveCard/style.ts
@@ -36,4 +36,8 @@ export const styles = StyleSheet.create({
     position: 'absolute',
     right: 0,
   },
+  gameTimeIconContainer: {
+    position: 'absolute',
+    left: 0,
+  },
 });

--- a/packages/TorneloScoresheet/src/components/TimePickerSheet/TimePickerSheet.tsx
+++ b/packages/TorneloScoresheet/src/components/TimePickerSheet/TimePickerSheet.tsx
@@ -28,7 +28,7 @@ const TimePickerSheet: React.FC<TimePickerSheetProps> = ({
 
   // refresh game time whenever it changes
   useEffect(() => {
-    setDate(new Date(1, 1, 1, gameTime.hours + 1, gameTime.minutes, 0));
+    setDate(new Date(1, 1, 1, gameTime.hours, gameTime.minutes, 0));
   }, [gameTime]);
 
   return (

--- a/packages/TorneloScoresheet/src/components/TimePickerSheet/TimePickerSheet.tsx
+++ b/packages/TorneloScoresheet/src/components/TimePickerSheet/TimePickerSheet.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+import { View } from 'react-native';
+import DatePicker from 'react-native-date-picker';
+import { GameTime } from '../../types/ChessMove';
+import PrimaryButton from '../PrimaryButton/PrimaryButton';
+import Sheet from '../Sheet/Sheet';
+import { styles } from './style';
+
+export type TimePickerSheetProps = {
+  gameTime: GameTime;
+  visible: boolean;
+  dismiss: () => void;
+  setGameTime: (gameTime: GameTime | undefined) => void;
+};
+
+const TimePickerSheet: React.FC<TimePickerSheetProps> = ({
+  gameTime,
+  visible,
+  dismiss,
+  setGameTime,
+}) => {
+  // set day/month/year not important
+  // date should be + 1 on hours for it to display properly,
+  // this is taken into account when setting the date
+  const [date, setDate] = useState(
+    new Date(1, 1, 1, gameTime.hours, gameTime.minutes, 0),
+  );
+
+  // refresh game time whenever it changes
+  useEffect(() => {
+    setDate(new Date(1, 1, 1, gameTime.hours + 1, gameTime.minutes, 0));
+  }, [gameTime]);
+
+  return (
+    <Sheet dismiss={dismiss} visible={visible} title={'Set move time'}>
+      <View style={styles.container}>
+        <DatePicker
+          style={styles.timeBox}
+          date={date}
+          onDateChange={setDate}
+          mode={'time'}
+          locale={'fr'}
+          is24hourSource={'locale'}
+        />
+        <View style={styles.buttonContainer}>
+          <PrimaryButton
+            style={styles.buttons}
+            label="remove"
+            onPress={() => setGameTime(undefined)}
+          />
+          <PrimaryButton
+            label="confirm"
+            style={styles.buttons}
+            onPress={() => {
+              setGameTime({
+                hours: date.getHours(),
+                minutes: date.getMinutes(),
+              });
+            }}
+          />
+        </View>
+      </View>
+    </Sheet>
+  );
+};
+
+export default TimePickerSheet;

--- a/packages/TorneloScoresheet/src/components/TimePickerSheet/style.ts
+++ b/packages/TorneloScoresheet/src/components/TimePickerSheet/style.ts
@@ -1,0 +1,21 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    display: 'flex',
+    alignItems: 'center',
+    paddingVertical: 15,
+  },
+  timeBox: {
+    marginTop: 25,
+    marginBottom: 65,
+  },
+  buttonContainer: {
+    display: 'flex',
+    flexDirection: 'row',
+  },
+  buttons: {
+    height: 70,
+    marginHorizontal: 10,
+  },
+});

--- a/packages/TorneloScoresheet/src/hooks/appMode/graphicalRecordingState.ts
+++ b/packages/TorneloScoresheet/src/hooks/appMode/graphicalRecordingState.ts
@@ -8,6 +8,7 @@ import {
 import { ChessGameResult, PlayerColour } from '../../types/ChessGameInfo';
 import {
   ChessPly,
+  GameTime,
   MovePly,
   MoveSquares,
   PieceType,
@@ -30,6 +31,7 @@ type GraphicalRecordingStateHookType = [
     skipTurnAndProcessMove: (move: MoveSquares, promotion?: PieceType) => void;
     generatePgn: (winner: PlayerColour | null) => Result<string>;
     toggleDraw: (drawIndex: number) => void;
+    setGameTime: (index: number, gameTime: GameTime | undefined) => void;
   },
 ];
 
@@ -223,6 +225,23 @@ export const makeUseGraphicalRecordingState =
       });
     };
 
+    const setGameTime = (index: number, gameTime: GameTime | undefined) => {
+      setAppModeState(graphicalRecordingState => {
+        // Do nothing if we aren't in graphical recording mode
+        if (graphicalRecordingState.mode !== AppMode.GraphicalRecording) {
+          return graphicalRecordingState;
+        }
+
+        // Otherwise, set the game time of the desired move
+        return {
+          ...graphicalRecordingState,
+          moveHistory: graphicalRecordingState.moveHistory.map((el, i) =>
+            i === index ? { ...el, gameTime } : el,
+          ),
+        };
+      });
+    };
+
     return [
       appModeState,
       {
@@ -237,6 +256,7 @@ export const makeUseGraphicalRecordingState =
         skipTurnAndProcessMove,
         generatePgn,
         toggleDraw,
+        setGameTime,
       },
     ];
   };

--- a/packages/TorneloScoresheet/src/hooks/appMode/tablePairingState.ts
+++ b/packages/TorneloScoresheet/src/hooks/appMode/tablePairingState.ts
@@ -40,6 +40,7 @@ export const makeUseTablePairingState =
         pairing: appModeState.pairing,
         moveHistory: [],
         board,
+        startTime: new Date().getTime(),
         currentPlayer,
       });
     };

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
@@ -21,7 +21,13 @@ import {
   ROOK,
 } from '../../style/images';
 import { Player, PlayerColour } from '../../types/ChessGameInfo';
-import { PieceType, MoveSquares, ChessPly, Move } from '../../types/ChessMove';
+import {
+  PieceType,
+  MoveSquares,
+  ChessPly,
+  Move,
+  GameTime,
+} from '../../types/ChessMove';
 import { styles } from './style';
 import { fullName } from '../../util/player';
 import Signature from '../../components/Signature/Signature';
@@ -30,6 +36,7 @@ import { useError } from '../../context/ErrorContext';
 import { isError } from '../../types/Result';
 import PrimaryText from '../../components/PrimaryText/PrimaryText';
 import MoveOptionsSheet, { EditingMove } from './MoveOptionsSheet';
+import TimePickerSheet from '../../components/TimePickerSheet/TimePickerSheet';
 
 const GraphicalRecording: React.FC = () => {
   // app mode hook unpacking
@@ -38,6 +45,7 @@ const GraphicalRecording: React.FC = () => {
   const makeMove = graphicalRecordingState?.[1].move;
   const undoLastMove = graphicalRecordingState?.[1].undoLastMove;
   const isPawnPromotion = graphicalRecordingState?.[1].isPawnPromotion;
+  const setGameTime = graphicalRecordingState?.[1].setGameTime;
   const skipTurn = graphicalRecordingState?.[1].skipTurn;
   const isOtherPlayersPiece = graphicalRecordingState?.[1].isOtherPlayersPiece;
   const skipTurnAndProcessMove =
@@ -51,9 +59,16 @@ const GraphicalRecording: React.FC = () => {
   );
   const [showPromotion, setShowPromotion] = useState(false);
   const [pgn, setPgn] = useState('');
+  const [showTimeSheet, setShowTimeSheet] = useState(false);
   const [, showError] = useError();
   const [showEndGame, setShowEndGame] = useState(false);
   const [showSignature, setShowSignature] = useState(false);
+  const [moveGameTime, setMoveGameTime] = useState<GameTime>({
+    hours: 0,
+    minutes: 0,
+  });
+  const [moveGameTimeIndex, setMoveGameTimeIndex] = useState(0);
+
   const goToEndGame = graphicalRecordingState?.[1].goToEndGame;
   const [selectedWinner, setSelectedWinner] = useState<
     undefined | Player | null
@@ -97,7 +112,11 @@ const GraphicalRecording: React.FC = () => {
     {
       text: 'time',
       onPress: () => {
-        return;
+        if (graphicalRecordingState) {
+          showSelectGameTimeSheet(
+            graphicalRecordingState?.[0].moveHistory.length - 1,
+          );
+        }
       },
       icon: <ICON_CLOCK height={40} fill={colours.white} />,
     },
@@ -227,7 +246,6 @@ const GraphicalRecording: React.FC = () => {
       setShowEndGame(false);
       return;
     }
-    console.log(pgnResult.data);
     setPgn(pgnResult.data);
 
     // if pgn can be generated -> prompt user for signature
@@ -310,6 +328,52 @@ const GraphicalRecording: React.FC = () => {
 
   const handleDismissMoveOptions = () => setEditingMove(undefined);
 
+  /**
+   * Calculates the game time since the game started
+   * @returns the game time
+   */
+  const getCurrentGameTime = (): GameTime => {
+    if (graphicalRecordingState) {
+      const totalMiliseconds =
+        new Date().getTime() - graphicalRecordingState[0].startTime;
+      const totalMinutes = totalMiliseconds / (1000 * 60);
+
+      // calculate time since start
+      return {
+        hours: totalMinutes / 60,
+        minutes: totalMinutes % 60,
+      };
+    }
+
+    // should never reach this code since graphical state should not be numm
+    return { hours: 0, minutes: 0 };
+  };
+
+  const showSelectGameTimeSheet = (index: number): void => {
+    // store index, set the current game time for that move, then show sheet
+    setMoveGameTimeIndex(index);
+    setMoveGameTime(getMoveGameTime());
+    setShowTimeSheet(true);
+  };
+
+  /**
+   * Gets the game time associated with the move index stored
+   * Will return the time since the start of the game if the current move has no time
+   * @returns The game time
+   */
+  const getMoveGameTime = (): GameTime => {
+    if (graphicalRecordingState) {
+      const gameTime =
+        graphicalRecordingState[0].moveHistory[moveGameTimeIndex]?.gameTime;
+
+      // return gameTime associated with move if it exists else current game time
+      return gameTime ? gameTime : getCurrentGameTime();
+    }
+
+    // un reachable code, graphical state should never be null
+    return { hours: 0, minutes: 0 };
+  };
+
   useEffect(() => {
     scrollRef.current?.scrollToEnd();
   }, [graphicalRecordingMode?.moveHistory]);
@@ -333,6 +397,7 @@ const GraphicalRecording: React.FC = () => {
           />
           <MoveOptionsSheet
             editingMove={editingMove}
+            handleGameTime={showSelectGameTimeSheet}
             dismiss={handleDismissMoveOptions}
           />
           <Signature
@@ -348,6 +413,18 @@ const GraphicalRecording: React.FC = () => {
                 : fullName(graphicalRecordingMode.pairing.players[1])
             }
           />
+          <TimePickerSheet
+            dismiss={() => setShowTimeSheet(false)}
+            visible={showTimeSheet}
+            gameTime={moveGameTime}
+            setGameTime={(gameTime: GameTime | undefined) => {
+              if (setGameTime) {
+                setGameTime(moveGameTimeIndex, gameTime);
+              }
+              setShowTimeSheet(false);
+            }}
+          />
+
           {/*----- body ----- */}
           <View style={styles.placeholder}>
             <PrimaryText label="Placeholder" size={30} />

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/MoveOptionsSheet.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/MoveOptionsSheet.tsx
@@ -15,10 +15,15 @@ export type EditingMove = {
 
 type MoveOptionsSheetProps = {
   editingMove: EditingMove | undefined;
+  handleGameTime: (index: number) => void;
   dismiss: () => void;
 };
 
-const MoveOptionsSheet = ({ editingMove, dismiss }: MoveOptionsSheetProps) => {
+const MoveOptionsSheet = ({
+  editingMove,
+  handleGameTime,
+  dismiss,
+}: MoveOptionsSheetProps) => {
   const recordingState = useGraphicalRecordingState();
   const actions = recordingState?.[1];
 
@@ -40,7 +45,15 @@ const MoveOptionsSheet = ({ editingMove, dismiss }: MoveOptionsSheetProps) => {
       dismiss={dismiss}
       title="Move options">
       <MoveOption
-        onPress={() => undefined}
+        onPress={() => {
+          if (editingMove) {
+            handleGameTime(
+              editingMove.moveIndex * 2 +
+                (editingMove.colour === PlayerColour.Black ? 1 : 0),
+            );
+          }
+          dismiss();
+        }}
         colour={colours.primary}
         icon={<ICON_CLOCK color={colours.white} />}
         label="Record time"

--- a/packages/TorneloScoresheet/src/types/AppModeState.ts
+++ b/packages/TorneloScoresheet/src/types/AppModeState.ts
@@ -1,6 +1,6 @@
 import { BoardPosition } from './ChessBoardPositions';
 import { ChessGameInfo, ChessGameResult, PlayerColour } from './ChessGameInfo';
-import { ChessPly } from './ChessMove';
+import { ChessPly, GameTime } from './ChessMove';
 
 export enum AppMode {
   EnterPgn,
@@ -53,6 +53,7 @@ export type TablePairingMode = {
 
 export type GraphicalRecordingMode = {
   mode: AppMode.GraphicalRecording;
+  startTime: number;
   pairing: ChessGameInfo;
   moveHistory: ChessPly[];
   board: BoardPosition[];

--- a/packages/TorneloScoresheet/src/types/ChessMove.ts
+++ b/packages/TorneloScoresheet/src/types/ChessMove.ts
@@ -35,6 +35,11 @@ export enum PlyTypes {
   SkipPly,
 }
 
+export type GameTime = {
+  hours: number;
+  minutes: number;
+};
+
 // Information about a given ply
 export type PlyInfo = {
   moveNo: number;
@@ -42,6 +47,7 @@ export type PlyInfo = {
   player: PlayerColour;
   type: PlyTypes;
   drawOffer: boolean;
+  gameTime?: GameTime;
 };
 
 // A move ply is a recorded ply that involved


### PR DESCRIPTION
We can now add time to the move
The time is relative to the start of the game

Changes made: 
- ChessPly now has an optional gameTime property
- MoveCard now displays clock icon if a move has a time attached
- GraphicalRecordingState now stores the time of the game starting
- new TimePickerSheet component allows editing a time for a move
- Added set time functionality to GraphicalRecording state
- Updated GraphicalRecodring page and the move options sheet to allow recording time 

https://user-images.githubusercontent.com/26475724/182061531-71b125d4-9260-4330-89ab-e624e2bd9089.mp4


