### PR TITLE
Hide Navigation bar on android devices

### DIFF
--- a/packages/TorneloScoresheet/android/app/src/main/java/com/chessscoresheet/MainActivity.java
+++ b/packages/TorneloScoresheet/android/app/src/main/java/com/chessscoresheet/MainActivity.java
@@ -1,6 +1,8 @@
 package com.torneloscoresheet;
 
 import com.facebook.react.ReactActivity;
+import android.os.Bundle;
+import android.view.View;
 
 public class MainActivity extends ReactActivity {
 
@@ -12,4 +14,27 @@ public class MainActivity extends ReactActivity {
   protected String getMainComponentName() {
     return "TorneloScoresheet";
   }
+
+  @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        hideNavigationBar();
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasFocus) {
+        super.onWindowFocusChanged(hasFocus);
+        if (hasFocus) {
+            hideNavigationBar();
+        }
+    }
+
+    private void hideNavigationBar() {
+        getWindow().getDecorView().setSystemUiVisibility(View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+               | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+               | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+               | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+               | View.SYSTEM_UI_FLAG_FULLSCREEN
+               | View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY);
+    }
 }


### PR DESCRIPTION
The navigation bar will now be hidden on Android.
This allows those of us simulating the Nexus 9 tablete to see the bottom of the screen