### PR TITLE
Refactor the signature handling logic

### DIFF
--- a/packages/TorneloScoresheet/src/components/Signature/Signature.tsx
+++ b/packages/TorneloScoresheet/src/components/Signature/Signature.tsx
@@ -41,7 +41,7 @@ const Signature: React.FC<SignatureProps> = ({
   };
 
   const resultText = (winnerName: string | null, playerName: string | null) => {
-    return winnerName === null ? 1 : playerName === winnerName ? 1 : 0;
+    return winnerName === null ? '1' : playerName === winnerName ? '1' : '0';
   };
 
   return (
@@ -55,39 +55,56 @@ const Signature: React.FC<SignatureProps> = ({
           {'Confirm Result'}
         </PrimaryText>
         <View style={styles.resultArea}>
-          <PrimaryText
-            style={styles.resultText}
-            weight={FontWeight.Bold}
-            size={40}
-            colour={colours.darkenedElements}>
-            {`${fullName(white)} \n `}
-            {`${resultText(winnerName, fullName(white))}`}
-            <PieceAsset
-              piece={{ type: PieceType.King, player: white.color }}
+          <View style={styles.resultAreaColumn}>
+            <PrimaryText
+              weight={FontWeight.Bold}
               size={40}
+              colour={colours.darkenedElements}
+              label={fullName(white)}
             />
-          </PrimaryText>
-          <PrimaryText
-            style={styles.resultText}
-            weight={FontWeight.Bold}
-            size={40}
-            colour={colours.darkenedElements}>
-            {`${fullName(black)} \n`}
-            <PieceAsset
-              piece={{ type: PieceType.King, player: black.color }}
+            <View style={styles.scoreAndColourRow}>
+              <PrimaryText
+                weight={FontWeight.Bold}
+                size={40}
+                label={resultText(winnerName, fullName(white))}
+              />
+              <PieceAsset
+                piece={{ type: PieceType.King, player: white.color }}
+                size={40}
+                style={styles.pieceOnRightOfScore}
+              />
+            </View>
+          </View>
+          <View style={styles.resultAreaColumn}>
+            <PrimaryText
+              weight={FontWeight.Bold}
               size={40}
+              colour={colours.darkenedElements}
+              label={fullName(black)}
             />
-            {`${resultText(winnerName, fullName(black))}`}
-          </PrimaryText>
+            <View style={styles.scoreAndColourRow}>
+              <PieceAsset
+                piece={{ type: PieceType.King, player: black.color }}
+                size={40}
+                style={styles.pieceOnLeftOfScore}
+              />
+              <PrimaryText
+                weight={FontWeight.Bold}
+                size={40}
+                colour={colours.darkenedElements}
+                label={resultText(winnerName, fullName(black))}
+              />
+            </View>
+          </View>
         </View>
         <View style={styles.signatureArea}>
           <PrimaryText
             style={styles.messageText}
             weight={FontWeight.Bold}
             size={30}
-            colour={colours.darkenedElements}>
-            {`Signature of ${player}`}
-          </PrimaryText>
+            colour={colours.darkenedElements}
+            label={`Signature of ${player}`}
+          />
           <SignatureCapture
             onSaveEvent={handleSaveSignature}
             saveImageFileInExtStorage={false}
@@ -95,7 +112,7 @@ const Signature: React.FC<SignatureProps> = ({
             style={styles.signature}
             showNativeButtons={false}
             showTitleLabel={false}
-            viewMode={'portrait'}
+            viewMode="portrait"
           />
         </View>
         <View style={styles.buttonArea}>

--- a/packages/TorneloScoresheet/src/components/Signature/style.ts
+++ b/packages/TorneloScoresheet/src/components/Signature/style.ts
@@ -3,7 +3,6 @@ import { colours } from '../../style/colour';
 
 export const styles = StyleSheet.create({
   signature: {
-    width: '100%',
     height: 150,
   },
 
@@ -21,25 +20,33 @@ export const styles = StyleSheet.create({
   },
   messageText: {
     textAlign: 'center',
-    minWidth: 500,
-  },
-
-  resultText: {
-    textAlign: 'center',
-    minWidth: 500,
-    marginTop: 25,
+    minWidth: 650,
   },
 
   signatureArea: {
-    marginTop: 15,
+    marginVertical: 25,
   },
 
   resultArea: {
     flexDirection: 'row',
     justifyContent: 'space-around',
-    height: 150,
     marginTop: 10,
+    paddingVertical: 10,
     backgroundColor: colours.primary20,
     borderRadius: 20,
   },
+  resultAreaColumn: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-around',
+    paddingVertical: 10,
+  },
+  scoreAndColourRow: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  pieceOnRightOfScore: { marginLeft: 10 },
+  pieceOnLeftOfScore: { marginRight: 10 },
 });


### PR DESCRIPTION
Written by Llio and I :)))

This PR was originally created to fix a bug, but we found some other small issues to fix along the way :)

- removed side effects in the ternaries
- fixed a bug where confirming the second player's signature did
nothing
- updated the styling of the result display in the signature component
- use a reference to store the state of the current player's signature;
clearly the signature library we are using is doing some crazy shit
with the callback we give it, because it ends up having stale state :(;
so instead of using state, we now use a reference, which never becomes
stale