### PR TITLE
simplified toolbar by putting arbiter/player mode transition and recording mode toggle in new files

### DIFF
--- a/packages/TorneloScoresheet/src/components/Toolbar/ArbiterAndPlayerModeDisplay.tsx
+++ b/packages/TorneloScoresheet/src/components/Toolbar/ArbiterAndPlayerModeDisplay.tsx
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import { View } from 'react-native';
+import {
+  useAppModeState,
+  useArbiterRecordingState,
+  useArbiterResultDisplayState,
+  useArbiterTablePairingState,
+  useRecordingState,
+  useResultDisplayState,
+  useTablePairingState,
+} from '../../context/AppModeStateContext';
+import {
+  isArbiterFromPlayerMode,
+  isArbiterMode,
+} from '../../types/AppModeState';
+import IconButton from '../IconButton/IconButton';
+import Pin from '../Pin/Pin';
+import PrimaryText, { FontWeight } from '../PrimaryText/PrimaryText';
+import Sheet from '../Sheet/Sheet';
+import { styles } from './style';
+import { AppMode } from '../../types/AppModeState';
+
+export type ArbiterAndPlayerModeDisplayProps = {
+  currentTextColour: string;
+};
+
+const ArbiterAndPlayerModeDisplay: React.FC<
+  ArbiterAndPlayerModeDisplayProps
+> = ({ currentTextColour }) => {
+  const appModeState = useAppModeState();
+  const [showArbiterSheet, setShowArbiterSheet] = useState(false);
+
+  const voidReturn: () => void = () => {
+    return;
+  };
+  const appModeArbiterTransition: Record<AppMode, () => void> = {
+    [AppMode.ArbiterRecording]: voidReturn,
+    [AppMode.ArbiterTablePairing]: voidReturn,
+    [AppMode.ArbiterResultDisplay]: voidReturn,
+    [AppMode.EnterPgn]: voidReturn,
+    [AppMode.Recording]:
+      useRecordingState()?.[1].goToArbiterGameMode ?? voidReturn,
+    [AppMode.PairingSelection]: voidReturn,
+    [AppMode.ResultDisplay]:
+      useResultDisplayState()?.[1].goToArbiterMode ?? voidReturn,
+    [AppMode.TablePairing]:
+      useTablePairingState()?.[1].goToArbiterGameMode ?? voidReturn,
+  };
+
+  const appModePlayerTransition: Record<AppMode, () => void> = {
+    [AppMode.EnterPgn]: voidReturn,
+    [AppMode.PairingSelection]: voidReturn,
+    [AppMode.TablePairing]: voidReturn,
+    [AppMode.Recording]: voidReturn,
+    [AppMode.ResultDisplay]: voidReturn,
+    [AppMode.ArbiterRecording]:
+      useArbiterRecordingState()?.[1].goToRecordingMode ?? voidReturn,
+    [AppMode.ArbiterTablePairing]:
+      useArbiterTablePairingState()?.[1].goToTablePairingMode ?? voidReturn,
+    [AppMode.ArbiterResultDisplay]:
+      useArbiterResultDisplayState()?.[1].goToResultDisplayMode ?? voidReturn,
+  };
+
+  const arbiterModeLockDisplay = () => {
+    if (isArbiterFromPlayerMode(appModeState.mode)) {
+      return 'Arbiter';
+    } else if (!isArbiterMode(appModeState.mode)) {
+      return 'Player';
+    }
+    return 'Placeholder';
+  };
+  const handlePlayerPress = () => {
+    //go back to player mode
+    appModePlayerTransition[appModeState.mode]();
+  };
+
+  const handleArbiterPress = () => {
+    //display the pin
+    setShowArbiterSheet((a: any) => !a);
+  };
+
+  const handleArbiterVerify = () => {
+    //pin is correct - move to arbiter mode
+    setShowArbiterSheet(false);
+    appModeArbiterTransition[appModeState.mode]();
+  };
+  return (
+    <>
+      <Sheet
+        title="Arbiter Mode"
+        dismiss={() => setShowArbiterSheet(false)}
+        visible={showArbiterSheet}>
+        <PrimaryText
+          style={styles.enterPinText}
+          size={40}
+          weight={FontWeight.Bold}
+          label={'Enter Pin'}
+        />
+        <Pin onPress={handleArbiterVerify} />
+      </Sheet>
+      {arbiterModeLockDisplay() === 'Player' && (
+        <IconButton
+          icon="lock-open"
+          onPress={handleArbiterPress}
+          colour={currentTextColour}
+        />
+      )}
+      {arbiterModeLockDisplay() === 'Arbiter' && (
+        <IconButton
+          icon="lock"
+          onPress={handlePlayerPress}
+          colour={currentTextColour}
+        />
+      )}
+      {arbiterModeLockDisplay() === 'Placeholder' && (
+        <View style={styles.placeHolderButton} />
+      )}
+    </>
+  );
+};
+
+export default ArbiterAndPlayerModeDisplay;

--- a/packages/TorneloScoresheet/src/components/Toolbar/ToggleRecordingMode.tsx
+++ b/packages/TorneloScoresheet/src/components/Toolbar/ToggleRecordingMode.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { View } from 'react-native';
+import {
+  useAppModeState,
+  useRecordingState,
+} from '../../context/AppModeStateContext';
+import { colours } from '../../style/colour';
+import { AppMode } from '../../types/AppModeState';
+import IconButton from '../IconButton/IconButton';
+import { styles } from './style';
+
+const ToggleRecordingMode: React.FC = () => {
+  const appModeState = useAppModeState();
+  const recordingState = useRecordingState();
+  const toggleRecordingModeIconDisplay = () => {
+    if (appModeState.mode === AppMode.Recording) {
+      if (appModeState.type === 'Graphical') {
+        return 'Graphical';
+      }
+      return 'Text';
+    }
+    return 'Placeholder';
+  };
+  const voidReturn: () => void = () => {
+    return;
+  };
+  const toggleRecordingState =
+    recordingState?.[1].toggleRecordingMode ?? voidReturn;
+  const handleRecordingModeTogglePress = () => {
+    //if in Graphic Game Mode, move to text recording mode
+    //if in Text Recording Mode, move to Graphic Game Mode
+    if (!recordingState) {
+      return;
+    }
+    toggleRecordingState();
+  };
+  return (
+    <>
+      {toggleRecordingModeIconDisplay() === 'Graphical' && (
+        <IconButton
+          icon="keyboard"
+          onPress={handleRecordingModeTogglePress}
+          colour={colours.white}
+        />
+      )}
+      {toggleRecordingModeIconDisplay() === 'Text' && (
+        <IconButton
+          icon="grid-view"
+          onPress={handleRecordingModeTogglePress}
+          colour={colours.white}
+        />
+      )}
+      {toggleRecordingModeIconDisplay() === 'Placeholder' && (
+        <View style={styles.placeHolderButton} />
+      )}
+    </>
+  );
+};
+
+export default ToggleRecordingMode;


### PR DESCRIPTION
In the last PR, Malo mentioned that the toolbar was getting cluttered so I separated out the toggle between text and graphical mode and the switching from arbiter to player mode. 