### PR TITLE
Add SAN notation to move list

### DIFF
--- a/packages/TorneloScoresheet/__tests__/chessEngine.test.ts
+++ b/packages/TorneloScoresheet/__tests__/chessEngine.test.ts
@@ -1,5 +1,6 @@
 import moment from 'moment';
 import { chessEngine } from '../src/chessEngine/chessEngineInterface';
+import { MoveReturnType } from '../src/chessEngine/chessTsChessEngine';
 import { BoardPosition, Position } from '../src/types/ChessBoardPositions';
 import { PlayerColour } from '../src/types/ChessGameInfo';
 import {
@@ -813,6 +814,7 @@ describe('makeMove', () => {
         type: PieceType.Pawn,
         player: PlayerColour.White,
       },
+      san: 'e4',
     },
     {
       name: 'normal illegal move',
@@ -827,6 +829,7 @@ describe('makeMove', () => {
         type: PieceType.Pawn,
         player: PlayerColour.White,
       },
+      san: 'e2e5',
     },
     {
       name: 'en passant capture',
@@ -842,6 +845,7 @@ describe('makeMove', () => {
         player: PlayerColour.White,
       },
       captured: 'p',
+      san: 'fxe6',
     },
     {
       name: 'checkmate',
@@ -856,6 +860,7 @@ describe('makeMove', () => {
         type: PieceType.Rook,
         player: PlayerColour.White,
       },
+      san: 'Rd8#',
     },
     {
       name: 'en passant capture',
@@ -871,6 +876,7 @@ describe('makeMove', () => {
         type: PieceType.Pawn,
         player: PlayerColour.Black,
       },
+      san: 'fxe3',
     },
     {
       name: 'regular move',
@@ -885,6 +891,7 @@ describe('makeMove', () => {
         type: PieceType.Knight,
         player: PlayerColour.Black,
       },
+      san: 'Ne7',
     },
     {
       name: 'capture',
@@ -900,6 +907,7 @@ describe('makeMove', () => {
         type: PieceType.Knight,
         player: PlayerColour.White,
       },
+      san: 'Nxg5',
     },
     {
       name: 'illegal move',
@@ -915,6 +923,7 @@ describe('makeMove', () => {
         type: PieceType.Knight,
         player: PlayerColour.White,
       },
+      san: 'Nb1xb7',
     },
     {
       name: 'impossible move -> from is not our piece',
@@ -929,6 +938,7 @@ describe('makeMove', () => {
         type: PieceType.Knight,
         player: PlayerColour.White,
       },
+      san: 'b7',
     },
     {
       name: 'impossible move -> to is our piece',
@@ -943,6 +953,7 @@ describe('makeMove', () => {
         type: PieceType.Knight,
         player: PlayerColour.White,
       },
+      san: 'c1',
     },
     {
       name: ' impossible move -> from is not on board',
@@ -957,6 +968,7 @@ describe('makeMove', () => {
         type: PieceType.Knight,
         player: PlayerColour.White,
       },
+      san: 'c1',
     },
     {
       name: 'impossible move -> to is not on board',
@@ -971,6 +983,7 @@ describe('makeMove', () => {
         type: PieceType.Knight,
         player: PlayerColour.White,
       },
+      san: 'p1',
     },
   ];
   const boardCorrect = (
@@ -995,16 +1008,16 @@ describe('makeMove', () => {
   };
   positions.forEach(function (position) {
     it(position.name, function () {
-      const result = chessEngine.makeMove(position.fen, {
+      const nextFenResult = chessEngine.makeMove(position.fen, {
         from: position.move.from as Position,
         to: position.move.to as Position,
       });
       if (position.possible) {
-        if (result !== null) {
-          const board = chessEngine.fenToBoardPositions(result);
+        if (nextFenResult !== null) {
+          const board = chessEngine.fenToBoardPositions(nextFenResult);
           expect(
-            result &&
-              result === position.next &&
+            nextFenResult &&
+              nextFenResult === position.next &&
               boardCorrect(
                 board,
                 {
@@ -1016,9 +1029,26 @@ describe('makeMove', () => {
           ).toBe(true);
         }
       } else {
-        expect(result).toBeNull();
+        expect(nextFenResult).toBeNull();
       }
     });
+
+    const moveSanResult = chessEngine.makeMove(
+      position.fen,
+      {
+        from: position.move.from as Position,
+        to: position.move.to as Position,
+      },
+      undefined,
+      MoveReturnType.MOVE_SAN,
+    );
+    if (position.possible) {
+      if (moveSanResult !== null) {
+        expect(moveSanResult).toEqual(position.san);
+      }
+    } else {
+      expect(moveSanResult).toBeNull();
+    }
   });
 });
 

--- a/packages/TorneloScoresheet/__tests__/useEditMoveState.test.ts
+++ b/packages/TorneloScoresheet/__tests__/useEditMoveState.test.ts
@@ -23,6 +23,7 @@ describe('Edit Move With Skip Ply', () => {
         type: PlyTypes.MovePly,
         move: { from: 'a1', to: 'a5' } as MoveSquares,
         drawOffer: false,
+        san: 'a1a5',
       },
       {
         moveNo: 1,
@@ -31,6 +32,7 @@ describe('Edit Move With Skip Ply', () => {
         move: { from: 'h8', to: 'h5' } as MoveSquares,
         type: PlyTypes.MovePly,
         drawOffer: false,
+        san: 'Rh8h5',
       },
     ];
     const editMoveState = generateEditMoveState(moveHistory, 0);
@@ -81,6 +83,7 @@ describe('Edit Move With Skip Ply', () => {
         type: PlyTypes.MovePly,
         move: { from: 'a1', to: 'a5' } as MoveSquares,
         drawOffer: false,
+        san: 'a1a5',
       },
       {
         moveNo: 1,
@@ -89,6 +92,7 @@ describe('Edit Move With Skip Ply', () => {
         move: { from: 'h8', to: 'h5' } as MoveSquares,
         type: PlyTypes.MovePly,
         drawOffer: false,
+        san: 'Rh8h5',
       },
       // if move 1 is skipped, this move wont be possible
       {
@@ -98,6 +102,7 @@ describe('Edit Move With Skip Ply', () => {
         type: PlyTypes.MovePly,
         move: { from: 'a5', to: 'a6' } as MoveSquares,
         drawOffer: false,
+        san: 'a6',
       },
     ];
     const editMoveState = generateEditMoveState(moveHistory, 0);
@@ -114,7 +119,9 @@ describe('Edit Move With Skip Ply', () => {
       expect(isError(result)).toBe(true);
     });
   });
+});
 
+describe('Edit move with Move Ply', () => {
   test('Edit move moveply sucess', async () => {
     const moveHistory = [
       {
@@ -125,6 +132,7 @@ describe('Edit Move With Skip Ply', () => {
         move: { from: 'a1', to: 'a5' } as MoveSquares,
         promotion: undefined,
         drawOffer: false,
+        san: 'a1a5',
       },
       {
         moveNo: 1,
@@ -133,6 +141,7 @@ describe('Edit Move With Skip Ply', () => {
         move: { from: 'h8', to: 'h5' } as MoveSquares,
         type: PlyTypes.MovePly,
         drawOffer: false,
+        san: 'Rh8h5',
       },
     ];
     const editMoveState = generateEditMoveState(moveHistory, 0);
@@ -168,6 +177,8 @@ describe('Edit Move With Skip Ply', () => {
             type: PlyTypes.MovePly,
             move: { from: 'a1', to: 'a4' } as MoveSquares,
             drawOffer: false,
+            san: 'Ra1a4',
+            promotion: undefined,
           },
           {
             ...editMoveState.moveHistory[1],
@@ -189,6 +200,7 @@ describe('Edit Move With Skip Ply', () => {
         move: { from: 'a1', to: 'a5' } as MoveSquares,
         promotion: undefined,
         drawOffer: false,
+        san: 'a1a5',
       },
       {
         moveNo: 1,
@@ -197,6 +209,7 @@ describe('Edit Move With Skip Ply', () => {
         move: { from: 'h8', to: 'h5' } as MoveSquares,
         type: PlyTypes.MovePly,
         drawOffer: false,
+        san: 'Rh8h5',
       },
     ];
     const editMoveState = generateEditMoveState(moveHistory, 0);
@@ -226,6 +239,7 @@ describe('Edit Move With Skip Ply', () => {
         type: PlyTypes.MovePly,
         move: { from: 'a1', to: 'a5' } as MoveSquares,
         drawOffer: false,
+        san: 'a1a5',
       },
       {
         moveNo: 1,
@@ -234,6 +248,7 @@ describe('Edit Move With Skip Ply', () => {
         move: { from: 'h8', to: 'h5' } as MoveSquares,
         type: PlyTypes.MovePly,
         drawOffer: false,
+        san: 'Rh8h5',
       },
       // if move 1 is does not land on a5, this move wont be possible
       {
@@ -243,6 +258,7 @@ describe('Edit Move With Skip Ply', () => {
         type: PlyTypes.MovePly,
         move: { from: 'a5', to: 'a6' } as MoveSquares,
         drawOffer: false,
+        san: 'a6',
       },
     ];
     const editMoveState = generateEditMoveState(moveHistory, 0);
@@ -273,6 +289,7 @@ describe('Edit Move With Skip Ply', () => {
         move: { from: 'a1', to: 'a5' } as MoveSquares,
         promotion: undefined,
         drawOffer: false,
+        san: 'a1a5',
       },
       {
         moveNo: 1,
@@ -281,6 +298,7 @@ describe('Edit Move With Skip Ply', () => {
         move: { from: 'h8', to: 'h5' } as MoveSquares,
         type: PlyTypes.MovePly,
         drawOffer: false,
+        san: 'Rh8h5',
       },
     ];
     const editMoveState = generateEditMoveState(moveHistory, 0);

--- a/packages/TorneloScoresheet/__tests__/useRecordingModeState.test.ts
+++ b/packages/TorneloScoresheet/__tests__/useRecordingModeState.test.ts
@@ -59,6 +59,7 @@ describe('recording moving', () => {
             type: PlyTypes.MovePly,
             player: PlayerColour.White,
             drawOffer: false,
+            san: 'e4',
           },
         ],
       });
@@ -78,6 +79,7 @@ describe('recording moving', () => {
         move: { from: 'a1', to: 'a5' } as MoveSquares,
         type: PlyTypes.MovePly,
         drawOffer: false,
+        san: 'a1a5',
       },
     ];
 
@@ -101,6 +103,7 @@ describe('recording moving', () => {
               'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
             move: { from: 'a1', to: 'a5' } as MoveSquares,
             drawOffer: false,
+            san: 'a1a5',
           },
           {
             moveNo: 1,
@@ -109,6 +112,7 @@ describe('recording moving', () => {
             startingFen: originFen,
             move,
             drawOffer: false,
+            san: 'Rh8h5',
           },
         ],
       });
@@ -141,6 +145,7 @@ describe('undoing last move', () => {
         type: PlyTypes.MovePly,
         move: { from: 'a1', to: 'a5' } as MoveSquares,
         drawOffer: false,
+        san: 'a1a5',
       },
     ];
     const graphicalState = generateRecordingState(moveHistory, 'Graphical');
@@ -166,6 +171,7 @@ describe('undoing last move', () => {
         startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
         move: { from: 'a1', to: 'a5' } as MoveSquares,
         drawOffer: false,
+        san: 'a1a5',
       },
       {
         moveNo: 1,
@@ -174,6 +180,7 @@ describe('undoing last move', () => {
         move: { from: 'h8', to: 'h5' } as MoveSquares,
         type: PlyTypes.MovePly,
         drawOffer: false,
+        san: 'Rh8h5',
       },
     ];
     const graphicalState = generateRecordingState(moveHistory, 'Graphical');
@@ -197,6 +204,7 @@ describe('undoing last move', () => {
               'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
             move: { from: 'a1', to: 'a5' } as MoveSquares,
             drawOffer: false,
+            san: 'a1a5',
           },
         ],
       });
@@ -241,6 +249,7 @@ describe('Skipping player turn', () => {
         type: PlyTypes.MovePly,
         move: { from: 'a1', to: 'a5' } as MoveSquares,
         drawOffer: false,
+        san: 'a1a5',
       },
     ];
     const graphicalState = generateRecordingState(moveHistory, 'Graphical');
@@ -307,6 +316,7 @@ describe('Auto Skip player turn', () => {
             type: PlyTypes.MovePly,
             move,
             drawOffer: false,
+            san: 'Rh8h5',
           },
         ],
         board: chessEngine.fenToBoardPositions(afterMoveResultingFen),
@@ -329,6 +339,7 @@ describe('Auto Skip player turn', () => {
         type: PlyTypes.MovePly,
         move: { from: 'a1', to: 'a5' } as MoveSquares,
         drawOffer: false,
+        san: 'a1a5',
       },
     ];
     const move = { from: 'a5', to: 'a6' } as MoveSquares;
@@ -356,6 +367,8 @@ describe('Auto Skip player turn', () => {
             type: PlyTypes.MovePly,
             move,
             startingFen: afterSkipResultingFen,
+            san: 'Ra6',
+            promotion: undefined,
             drawOffer: false,
           },
         ],
@@ -452,6 +465,7 @@ describe('Auto Skip player turn', () => {
         type: PlyTypes.MovePly,
         move: { from: 'a1', to: 'a5' } as MoveSquares,
         drawOffer: false,
+        san: 'a1a5',
       },
     ];
     const move = { from: 'a2', to: 'a8' } as MoveSquares;
@@ -484,6 +498,7 @@ describe('Auto Skip player turn', () => {
             promotion: PieceType.Queen,
             startingFen: afterSkipResultingFen,
             drawOffer: false,
+            san: 'a2axa8=Q',
           },
         ],
         board: chessEngine.fenToBoardPositions(afterMoveResultingFen),
@@ -505,6 +520,7 @@ describe('Generate pgn', () => {
             from: 'e2',
             to: 'e4',
           },
+          san: 'e4',
         },
         {
           moveNo: 2,
@@ -516,6 +532,7 @@ describe('Generate pgn', () => {
             from: 'd7',
             to: 'd5',
           },
+          san: '',
         },
         {
           moveNo: 3,
@@ -527,6 +544,7 @@ describe('Generate pgn', () => {
             from: 'e4',
             to: 'd5',
           },
+          san: '',
         },
         {
           moveNo: 4,
@@ -538,6 +556,7 @@ describe('Generate pgn', () => {
             from: 'd8',
             to: 'd7',
           },
+          san: '',
         },
         {
           moveNo: 5,
@@ -549,6 +568,7 @@ describe('Generate pgn', () => {
             from: 'd5',
             to: 'd6',
           },
+          san: '',
         },
         {
           moveNo: 6,
@@ -560,6 +580,7 @@ describe('Generate pgn', () => {
             from: 'd7',
             to: 'f5',
           },
+          san: '',
         },
         {
           moveNo: 7,
@@ -571,6 +592,7 @@ describe('Generate pgn', () => {
             from: 'd6',
             to: 'd7',
           },
+          san: '',
         },
         {
           moveNo: 8,
@@ -582,6 +604,7 @@ describe('Generate pgn', () => {
             from: 'f5',
             to: 'f4',
           },
+          san: '',
         },
         {
           moveNo: 9,
@@ -593,6 +616,7 @@ describe('Generate pgn', () => {
             from: 'd7',
             to: 'd8',
           },
+          san: '',
           promotion: PieceType.Queen,
         },
         {
@@ -605,6 +629,7 @@ describe('Generate pgn', () => {
             from: 'f4',
             to: 'f5',
           },
+          san: '',
         },
         {
           moveNo: 11,
@@ -616,6 +641,7 @@ describe('Generate pgn', () => {
             from: 'd2',
             to: 'e2',
           },
+          san: '',
         },
       ] as ChessPly[],
       'Graphical',
@@ -651,6 +677,7 @@ describe('Generate pgn', () => {
             from: 'e2',
             to: 'e4',
           },
+          san: '',
         },
         {
           moveNo: 2,
@@ -662,6 +689,7 @@ describe('Generate pgn', () => {
             from: 'd7',
             to: 'd5',
           },
+          san: '',
         },
         {
           moveNo: 3,
@@ -680,6 +708,7 @@ describe('Generate pgn', () => {
             from: 'd8',
             to: 'd7',
           },
+          san: '',
         },
         {
           moveNo: 5,
@@ -691,6 +720,7 @@ describe('Generate pgn', () => {
             from: 'd5',
             to: 'd6',
           },
+          san: '',
         },
         {
           moveNo: 6,
@@ -709,6 +739,7 @@ describe('Generate pgn', () => {
             from: 'd6',
             to: 'd7',
           },
+          san: '',
         },
         {
           moveNo: 8,
@@ -720,6 +751,7 @@ describe('Generate pgn', () => {
             from: 'f5',
             to: 'f4',
           },
+          san: '',
         },
         {
           moveNo: 9,
@@ -731,6 +763,7 @@ describe('Generate pgn', () => {
             from: 'd7',
             to: 'd8',
           },
+          san: '',
           promotion: PieceType.Queen,
         },
         {
@@ -743,6 +776,7 @@ describe('Generate pgn', () => {
             from: 'f4',
             to: 'f5',
           },
+          san: '',
         },
         {
           moveNo: 11,
@@ -754,6 +788,7 @@ describe('Generate pgn', () => {
             from: 'd2',
             to: 'e2',
           },
+          san: '',
         },
       ] as ChessPly[],
       'Graphical',
@@ -786,6 +821,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'e2',
             to: 'e4',
           },
+          san: '',
         },
         {
           moveNo: 2,
@@ -797,6 +833,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'd7',
             to: 'd5',
           },
+          san: '',
         },
         {
           moveNo: 3,
@@ -815,6 +852,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'd8',
             to: 'd7',
           },
+          san: '',
         },
         {
           moveNo: 5,
@@ -826,6 +864,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'd5',
             to: 'd6',
           },
+          san: '',
         },
         {
           moveNo: 6,
@@ -844,6 +883,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'd6',
             to: 'd7',
           },
+          san: '',
         },
         {
           moveNo: 8,
@@ -855,6 +895,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'f5',
             to: 'f4',
           },
+          san: '',
         },
         {
           moveNo: 9,
@@ -866,6 +907,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'd7',
             to: 'd8',
           },
+          san: '',
           promotion: PieceType.Queen,
         },
         {
@@ -878,6 +920,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'f4',
             to: 'f5',
           },
+          san: '',
         },
         {
           moveNo: 11,
@@ -889,6 +932,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'd2',
             to: 'e2',
           },
+          san: '',
         },
       ] as ChessPly[],
       'Graphical',
@@ -926,6 +970,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'e2',
             to: 'e4',
           },
+          san: '',
         },
         {
           moveNo: 2,
@@ -937,6 +982,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'd7',
             to: 'd5',
           },
+          san: '',
         },
         {
           moveNo: 3,
@@ -955,6 +1001,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'd8',
             to: 'd7',
           },
+          san: '',
         },
         {
           moveNo: 5,
@@ -966,6 +1013,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'd5',
             to: 'd6',
           },
+          san: '',
         },
         {
           moveNo: 6,
@@ -984,6 +1032,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'd6',
             to: 'd7',
           },
+          san: '',
         },
         {
           moveNo: 8,
@@ -995,6 +1044,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'f5',
             to: 'f4',
           },
+          san: '',
         },
         {
           moveNo: 9,
@@ -1007,6 +1057,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             to: 'd8',
           },
           promotion: PieceType.Queen,
+          san: '',
         },
         {
           moveNo: 10,
@@ -1018,6 +1069,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'f4',
             to: 'f5',
           },
+          san: '',
         },
         {
           moveNo: 11,
@@ -1029,6 +1081,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'd2',
             to: 'e2',
           },
+          san: '',
         },
       ] as ChessPly[],
       'Graphical',
@@ -1066,6 +1119,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'e2',
             to: 'e4',
           },
+          san: '',
         },
         {
           moveNo: 2,
@@ -1077,6 +1131,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'd7',
             to: 'd5',
           },
+          san: '',
         },
         {
           moveNo: 3,
@@ -1095,6 +1150,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'd8',
             to: 'd7',
           },
+          san: '',
         },
         {
           moveNo: 5,
@@ -1106,6 +1162,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'd5',
             to: 'd6',
           },
+          san: '',
         },
         {
           moveNo: 6,
@@ -1124,6 +1181,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'd6',
             to: 'd7',
           },
+          san: '',
         },
         {
           moveNo: 8,
@@ -1135,6 +1193,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'f5',
             to: 'f4',
           },
+          san: '',
         },
         {
           moveNo: 9,
@@ -1147,6 +1206,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             to: 'd8',
           },
           promotion: PieceType.Queen,
+          san: '',
         },
         {
           moveNo: 10,
@@ -1158,6 +1218,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'f4',
             to: 'f5',
           },
+          san: '',
         },
         {
           moveNo: 11,
@@ -1169,6 +1230,7 @@ describe('goToResultDisplayFromGraphicalRecording', () => {
             from: 'd2',
             to: 'e2',
           },
+          san: '',
         },
       ] as ChessPly[],
       'Graphical',
@@ -1205,6 +1267,7 @@ describe('Toggle Draw Offer', () => {
         type: PlyTypes.MovePly,
         move: { from: 'a1', to: 'a5' } as MoveSquares,
         drawOffer: false,
+        san: 'a1a5',
       },
     ];
     const graphicalState = generateRecordingState(moveHistory, 'Graphical');
@@ -1226,6 +1289,7 @@ describe('Toggle Draw Offer', () => {
             type: PlyTypes.MovePly,
             move: { from: 'a1', to: 'a5' } as MoveSquares,
             drawOffer: true,
+            san: 'a1a5',
           },
         ],
       });
@@ -1241,6 +1305,7 @@ describe('Toggle Draw Offer', () => {
         type: PlyTypes.MovePly,
         move: { from: 'a1', to: 'a5' } as MoveSquares,
         drawOffer: true,
+        san: 'a1a5',
       },
     ];
     const graphicalState = generateRecordingState(moveHistory, 'Graphical');
@@ -1262,6 +1327,7 @@ describe('Toggle Draw Offer', () => {
             type: PlyTypes.MovePly,
             move: { from: 'a1', to: 'a5' } as MoveSquares,
             drawOffer: false,
+            san: 'a1a5',
           },
         ],
       });
@@ -1277,6 +1343,7 @@ describe('Toggle Draw Offer', () => {
         startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
         move: { from: 'a1', to: 'a5' } as MoveSquares,
         drawOffer: false,
+        san: 'a1a5',
       },
       {
         moveNo: 1,
@@ -1285,6 +1352,7 @@ describe('Toggle Draw Offer', () => {
         move: { from: 'h8', to: 'h5' } as MoveSquares,
         type: PlyTypes.MovePly,
         drawOffer: false,
+        san: 'Rh8h5',
       },
     ];
     const graphicalState = generateRecordingState(moveHistory, 'Graphical');
@@ -1309,6 +1377,7 @@ describe('Toggle Draw Offer', () => {
               'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
             move: { from: 'a1', to: 'a5' } as MoveSquares,
             drawOffer: false,
+            san: 'a1a5',
           },
           {
             moveNo: 1,
@@ -1318,6 +1387,7 @@ describe('Toggle Draw Offer', () => {
             move: { from: 'h8', to: 'h5' } as MoveSquares,
             type: PlyTypes.MovePly,
             drawOffer: true,
+            san: 'Rh8h5',
           },
         ],
       });
@@ -1333,6 +1403,7 @@ describe('Toggle Draw Offer', () => {
         startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
         move: { from: 'a1', to: 'a5' } as MoveSquares,
         drawOffer: false,
+        san: 'a1a5',
       },
       {
         moveNo: 1,
@@ -1341,6 +1412,7 @@ describe('Toggle Draw Offer', () => {
         move: { from: 'h8', to: 'h5' } as MoveSquares,
         type: PlyTypes.MovePly,
         drawOffer: true,
+        san: 'Rh8h5',
       },
     ];
     const graphicalState = generateRecordingState(moveHistory, 'Graphical');
@@ -1365,6 +1437,7 @@ describe('Toggle Draw Offer', () => {
               'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
             move: { from: 'a1', to: 'a5' } as MoveSquares,
             drawOffer: false,
+            san: 'a1a5',
           },
           {
             moveNo: 1,
@@ -1374,6 +1447,7 @@ describe('Toggle Draw Offer', () => {
             move: { from: 'h8', to: 'h5' } as MoveSquares,
             type: PlyTypes.MovePly,
             drawOffer: false,
+            san: 'Rh8h5',
           },
         ],
       });
@@ -1391,6 +1465,7 @@ describe('Add Game time', () => {
         type: PlyTypes.MovePly,
         move: { from: 'a1', to: 'a5' } as MoveSquares,
         drawOffer: false,
+        san: 'a1a5',
       },
     ];
     const graphicalState = generateRecordingState(moveHistory, 'Graphical');
@@ -1415,6 +1490,7 @@ describe('Add Game time', () => {
             move: { from: 'a1', to: 'a5' } as MoveSquares,
             drawOffer: false,
             gameTime,
+            san: 'a1a5',
           },
         ],
       });
@@ -1430,6 +1506,7 @@ describe('Add Game time', () => {
         type: PlyTypes.MovePly,
         move: { from: 'a1', to: 'a5' } as MoveSquares,
         drawOffer: true,
+        san: 'a1a5',
         gameTime: { hours: 1, minutes: 1 },
       },
     ];
@@ -1452,6 +1529,7 @@ describe('Add Game time', () => {
             type: PlyTypes.MovePly,
             move: { from: 'a1', to: 'a5' } as MoveSquares,
             drawOffer: true,
+            san: 'a1a5',
           },
         ],
       });
@@ -1467,6 +1545,7 @@ describe('Add Game time', () => {
         startingFen: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
         move: { from: 'a1', to: 'a5' } as MoveSquares,
         drawOffer: false,
+        san: 'a1a5',
         gameTime: { hours: 1, minutes: 1 },
       },
       {
@@ -1476,6 +1555,7 @@ describe('Add Game time', () => {
         move: { from: 'h8', to: 'h5' } as MoveSquares,
         type: PlyTypes.MovePly,
         drawOffer: false,
+        san: 'Rh8h5',
       },
     ];
     const graphicalState = generateRecordingState(moveHistory, 'Graphical');
@@ -1501,6 +1581,7 @@ describe('Add Game time', () => {
             move: { from: 'a1', to: 'a5' } as MoveSquares,
             drawOffer: false,
             gameTime: newGameTime,
+            san: 'a1a5',
           },
           {
             moveNo: 1,
@@ -1510,6 +1591,7 @@ describe('Add Game time', () => {
             move: { from: 'h8', to: 'h5' } as MoveSquares,
             type: PlyTypes.MovePly,
             drawOffer: false,
+            san: 'Rh8h5',
           },
         ],
       });

--- a/packages/TorneloScoresheet/src/chessEngine/chessEngineInterface.ts
+++ b/packages/TorneloScoresheet/src/chessEngine/chessEngineInterface.ts
@@ -2,7 +2,7 @@ import { BoardPosition } from '../types/ChessBoardPositions';
 import { ChessGameInfo, PlayerColour } from '../types/ChessGameInfo';
 import { PieceType, MoveSquares, ChessPly } from '../types/ChessMove';
 import { Result } from '../types/Result';
-import { chessTsChessEngine } from './chessTsChessEngine';
+import { chessTsChessEngine, MoveReturnType } from './chessTsChessEngine';
 
 /**
  * The interface for the chess engine wrapper, this type is used all
@@ -27,12 +27,14 @@ export type ChessEngineInterface = {
    * @param startingFen the fen of the game state before the move
    * @param moveSquares the to and from positions of the move
    * @param promotion the to and from positions of the move
-   * @returns the next fen if move is possible else null
+   * @param returnType the return of this function, either the starting fen or the move's SAN
+   * @returns the next fen / move SAN if move is possible else null
    */
   makeMove: (
     startingFen: string,
     moveSquares: MoveSquares,
     promotion?: PieceType,
+    returnType?: MoveReturnType,
   ) => string | null;
 
   /**

--- a/packages/TorneloScoresheet/src/chessEngine/chessTsChessEngine.ts
+++ b/packages/TorneloScoresheet/src/chessEngine/chessTsChessEngine.ts
@@ -100,16 +100,23 @@ const fenToBoardPositions = (fen: string): BoardPosition[] => {
   return gameToPeiceArray(game);
 };
 
+export enum MoveReturnType {
+  NEXT_STARTING_FEN,
+  MOVE_SAN,
+}
+
 /**
  * Processes a move given the starting fen and to and from positions
  * @param fromFen the fen of the game state before the move
  * @param moveSquares the to and from positions of the move
- * @returns the next fen if move is possible else null
+ * @param returnType the return of this function, either the starting fen or the move's SAN
+ * @returns the next fen / move SAN if move is possible else null
  */
 const makeMove = (
   fromFen: string,
   moveSquares: MoveSquares,
   promotion?: PieceType,
+  returnType: MoveReturnType = MoveReturnType.NEXT_STARTING_FEN,
 ): string | null => {
   const game = new Chess(fromFen);
   const result = game.forceMove(
@@ -119,11 +126,19 @@ const makeMove = (
         promotion !== undefined ? chessTsPieceMap[promotion] : undefined,
     },
   );
+
+  // if move impossible return null
   if (result === null) {
     return null;
   }
 
-  return game.fen();
+  // if move is possible -> return next starting fen or the SAN of the move
+  switch (returnType) {
+    case MoveReturnType.NEXT_STARTING_FEN:
+      return game.fen();
+    case MoveReturnType.MOVE_SAN:
+      return result.san;
+  }
 };
 
 /**

--- a/packages/TorneloScoresheet/src/components/MoveCard/MoveCard.tsx
+++ b/packages/TorneloScoresheet/src/components/MoveCard/MoveCard.tsx
@@ -82,7 +82,7 @@ const moveString = (ply: ChessPly, isEditing: boolean): string => {
     return '-';
   }
 
-  return `${ply.move.from}->${ply.move.to}`;
+  return ply.san;
 };
 
 const blackPlyBackgroundColour = (ply: ChessPly | undefined) => ({

--- a/packages/TorneloScoresheet/src/hooks/appMode/recordingState.ts
+++ b/packages/TorneloScoresheet/src/hooks/appMode/recordingState.ts
@@ -1,5 +1,6 @@
 import { useContext } from 'react';
 import { chessEngine } from '../../chessEngine/chessEngineInterface';
+import { MoveReturnType } from '../../chessEngine/chessTsChessEngine';
 import {
   AppMode,
   AppModeState,
@@ -98,8 +99,24 @@ const processPlayerMove = (
   moveHistory: ChessPly[],
   promotion?: PieceType,
 ): ChessPly[] | null => {
+  const startingFen = getCurrentFen(moveHistory);
+
+  // process move
+  const moveSAN = chessEngine.makeMove(
+    startingFen,
+    moveSquares,
+    promotion,
+    MoveReturnType.MOVE_SAN,
+  );
+
+  // return null if move is impossible
+  if (!moveSAN) {
+    return null;
+  }
+
+  // build next play and return new history
   const nextPly: MovePly = {
-    startingFen: getCurrentFen(moveHistory),
+    startingFen,
     move: moveSquares,
     type: PlyTypes.MovePly,
     moveNo: Math.floor(moveHistory.length / 2) + 1,
@@ -107,13 +124,10 @@ const processPlayerMove = (
       moveHistory.length % 2 === 0 ? PlayerColour.White : PlayerColour.Black,
     promotion,
     drawOffer: false,
+    san: moveSAN,
   };
 
-  // return history array or null if move is not legal
-  return chessEngine.makeMove(nextPly.startingFen, nextPly.move, promotion) ===
-    null
-    ? null
-    : [...moveHistory, nextPly];
+  return [...moveHistory, nextPly];
 };
 
 export const makeUseRecordingState =

--- a/packages/TorneloScoresheet/src/types/ChessMove.ts
+++ b/packages/TorneloScoresheet/src/types/ChessMove.ts
@@ -56,6 +56,7 @@ export type MovePly = {
   move: MoveSquares;
   type: PlyTypes.MovePly;
   promotion?: PieceType;
+  san: string;
 } & PlyInfo;
 
 // A skip ply is a recorded ply that has been


### PR DESCRIPTION
The move list now displays the move is SAN (Standard Algebraic Notation), which is the standard way to communicate moves
The SAN will be:
- normal if the move is legal (ie the shortest possible string that uniquely identifies the move)
- fromto if the move is illegal (required to not have ambiguous SAN)

https://user-images.githubusercontent.com/26475724/186568846-fc441a60-9f1f-437c-859f-da4e86aae57d.mp4


