### PR TITLE
Arbiter mode display legality

### DIFF
--- a/packages/TorneloScoresheet/assets/documentation/ArbiterRecording.md
+++ b/packages/TorneloScoresheet/assets/documentation/ArbiterRecording.md
@@ -1,0 +1,10 @@
+# Arbiter Recording
+
+This page allows the arbiter to view all the past moves as well as their legality.
+
+The moves are visible in the table and are colour coded to represent differing legality statuses:
+
+- A Blue move means that move is in repetition, all other instances of that repetition are also in Blue
+- An orange move indicates a check mate
+- A grey move represents a stalemate
+- A Yellow move represents a draw

--- a/packages/TorneloScoresheet/src/components/MoveTable/MoveRow.tsx
+++ b/packages/TorneloScoresheet/src/components/MoveTable/MoveRow.tsx
@@ -3,16 +3,49 @@ import { View } from 'react-native';
 import PrimaryText, { FontWeight } from '../PrimaryText/PrimaryText';
 import { styles } from './style';
 import MoveCell from './MoveCell';
-import { Move } from '../../types/ChessMove';
+import { ChessPly, Move } from '../../types/ChessMove';
+import { colours, ColourType } from '../../style/colour';
 
 export type MoveRowProps = {
   move: Move;
   moveNumber: number;
 };
+const highlightColorForPly = (ply?: ChessPly): ColourType | undefined => {
+  if (!ply) {
+    return undefined;
+  }
+
+  if (ply.legality?.inCheckmate) {
+    return colours.lightOrange;
+  }
+
+  if (ply.legality?.inFiveFoldRepetition) {
+    return colours.darkBlue;
+  }
+
+  if (ply.legality?.inStalemate) {
+    return colours.lightGrey;
+  }
+
+  if (ply.legality?.inDraw) {
+    return colours.tertiary;
+  }
+
+  if (ply.legality?.inThreefoldRepetition) {
+    return colours.darkBlue;
+  }
+
+  return undefined;
+};
 
 const MoveRow: React.FC<MoveRowProps> = ({ move, moveNumber }) => {
   return (
-    <View style={styles.moveRowContainer}>
+    <View
+      style={[
+        styles.moveRowContainer,
+        // first move also needs top border
+        moveNumber === 1 ? styles.firstMoveContainer : {},
+      ]}>
       <View style={styles.moveNumberContainer}>
         <PrimaryText
           label={`${moveNumber}`}
@@ -21,8 +54,14 @@ const MoveRow: React.FC<MoveRowProps> = ({ move, moveNumber }) => {
         />
       </View>
       <View style={styles.moveDetailsContainer}>
-        <MoveCell ply={move.white} />
-        <MoveCell ply={move.black} />
+        <MoveCell
+          ply={move.white}
+          highlightColor={highlightColorForPly(move.white)}
+        />
+        <MoveCell
+          ply={move.black}
+          highlightColor={highlightColorForPly(move.black)}
+        />
       </View>
     </View>
   );

--- a/packages/TorneloScoresheet/src/components/MoveTable/style.tsx
+++ b/packages/TorneloScoresheet/src/components/MoveTable/style.tsx
@@ -2,10 +2,12 @@ import { StyleSheet } from 'react-native';
 
 export const styles = StyleSheet.create({
   movesContainer: {
-    borderTopColor: 'black',
-    borderTopWidth: 1,
     margin: 10,
     marginBottom: 40,
+  },
+  firstMoveContainer: {
+    borderTopColor: 'black',
+    borderTopWidth: 1,
   },
   moveRowContainer: {
     display: 'flex',

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/ArbiterRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/ArbiterRecording.tsx
@@ -4,11 +4,30 @@ import GraphicalModePlayerCard from '../../components/GraphicalModePlayerCard/Gr
 import { useArbiterRecordingState } from '../../context/AppModeStateContext';
 import { styles } from './style';
 import MoveTable from '../../components/MoveTable/MoveTable';
+import { ChessPly } from '../../types/ChessMove';
 
 const ArbiterRecording: React.FC = () => {
   const recordingModeState = useArbiterRecordingState();
   const recordingMode = recordingModeState?.[0];
+  const propagateRepetitions = (moves: ChessPly[]): ChessPly[] => {
+    const repetition = moves
+      .filter(
+        move =>
+          move.legality?.inFiveFoldRepetition ||
+          move.legality?.inThreefoldRepetition,
+      )
+      .map(move => move.startingFen.split('-')[0]?.concat('-') ?? '');
 
+    return moves.map(move => {
+      if ((move.startingFen.split('-')[0]?.concat('-') ?? '') in repetition) {
+        return {
+          ...move,
+          legality: { ...move.legality, inFiveFoldRepetition: true },
+        };
+      }
+      return { ...move };
+    });
+  };
   return (
     <>
       {recordingMode && (
@@ -25,7 +44,7 @@ const ArbiterRecording: React.FC = () => {
             />
           </View>
 
-          <MoveTable moves={recordingMode.moveHistory} />
+          <MoveTable moves={propagateRepetitions(recordingMode.moveHistory)} />
         </View>
       )}
     </>


### PR DESCRIPTION
This PR implements highlighting the moves in arbiter mode to represent legality.
For now all repetition moves are highlighted the same colour, in the future, it might make more sense to highlight different repetitions in different colours so the arbiter can make more sense of it.

The help sheet explains what the colours mean, but it is not working on android

**In this example there is repetition and a checkmate:**

https://user-images.githubusercontent.com/26475724/190940811-51b2bf19-e0a9-4f5c-b531-b3d1de0e50ca.mp4


**Stalemate:**


https://user-images.githubusercontent.com/26475724/190940818-f454bf06-3210-4bf5-a644-3fb06b922881.mp4


