### PR TITLE
Fixed typo in `generatePgn` type signature

### DIFF
--- a/packages/TorneloScoresheet/src/hooks/appMode/recordingState.ts
+++ b/packages/TorneloScoresheet/src/hooks/appMode/recordingState.ts
@@ -39,7 +39,7 @@ type recordingStateHookType = [
     ) => Result<undefined>;
     generatePgn: (
       winner: PlayerColour | null,
-      allowSkips: boolean,
+      allowSkips?: boolean,
     ) => Result<string>;
     toggleDraw: (drawIndex: number) => void;
     setGameTime: (index: number, gameTime: GameTime | undefined) => void;


### PR DESCRIPTION
This fixes a compilation error