### PR TITLE
Highlight repeated moves arbiter

### DIFF
--- a/packages/TorneloScoresheet/src/components/MoveTable/MoveCell.tsx
+++ b/packages/TorneloScoresheet/src/components/MoveTable/MoveCell.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View } from 'react-native';
+import { TouchableOpacity, View } from 'react-native';
 import { colours, ColourType } from '../../style/colour';
 import { ChessPly, GameTime } from '../../types/ChessMove';
 import { moveString } from '../../util/moves';
@@ -10,9 +10,14 @@ import Icon from 'react-native-vector-icons/Entypo';
 export type MoveCellProps = {
   ply?: ChessPly;
   highlightColor?: ColourType;
+  onCellSelect: (fen: string) => void;
 };
 
-const MoveCell: React.FC<MoveCellProps> = ({ ply, highlightColor }) => {
+const MoveCell: React.FC<MoveCellProps> = ({
+  ply,
+  highlightColor,
+  onCellSelect,
+}) => {
   const formatTime = (time?: GameTime): string => {
     if (!time) {
       return '--:--';
@@ -25,11 +30,17 @@ const MoveCell: React.FC<MoveCellProps> = ({ ply, highlightColor }) => {
   };
   return (
     <View style={styles.moveCellContainer}>
-      <View
-        style={[styles.moveSanTextBox, { backgroundColor: highlightColor }]}>
-        {ply && <PrimaryText size={25} label={moveString(ply, false)} />}
-      </View>
-
+      <TouchableOpacity
+        onPress={() => {
+          if (ply) {
+            onCellSelect(ply.startingFen);
+          }
+        }}>
+        <View
+          style={[styles.moveSanTextBox, { backgroundColor: highlightColor }]}>
+          {ply && <PrimaryText size={25} label={moveString(ply, false)} />}
+        </View>
+      </TouchableOpacity>
       <View style={styles.moveTimeTextBox}>
         {ply?.drawOffer && (
           <View style={styles.drawOfferIcon}>

--- a/packages/TorneloScoresheet/src/components/MoveTable/MoveCell.tsx
+++ b/packages/TorneloScoresheet/src/components/MoveTable/MoveCell.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { TouchableOpacity, View } from 'react-native';
 import { colours, ColourType } from '../../style/colour';
 import { ChessPly, GameTime } from '../../types/ChessMove';
-import { moveString } from '../../util/moves';
+import { getShortFenAfterMove, moveString } from '../../util/moves';
 import PrimaryText from '../PrimaryText/PrimaryText';
 import { styles } from './style';
 import Icon from 'react-native-vector-icons/Entypo';
@@ -18,6 +18,14 @@ const MoveCell: React.FC<MoveCellProps> = ({
   highlightColor,
   onCellSelect,
 }) => {
+  const processCellPress = (ply?: ChessPly): void => {
+    if (!ply) {
+      return;
+    }
+    let shortFenfromPly = getShortFenAfterMove(ply);
+    onCellSelect(shortFenfromPly);
+  };
+
   const formatTime = (time?: GameTime): string => {
     if (!time) {
       return '--:--';
@@ -31,13 +39,11 @@ const MoveCell: React.FC<MoveCellProps> = ({
   return (
     <View style={styles.moveCellContainer}>
       <TouchableOpacity
+        style={[styles.moveSanTextBox, { backgroundColor: highlightColor }]}
         onPress={() => {
-          if (ply) {
-            onCellSelect(ply.startingFen);
-          }
+          processCellPress(ply);
         }}>
-        <View
-          style={[styles.moveSanTextBox, { backgroundColor: highlightColor }]}>
+        <View>
           {ply && <PrimaryText size={25} label={moveString(ply, false)} />}
         </View>
       </TouchableOpacity>

--- a/packages/TorneloScoresheet/src/components/MoveTable/MoveRow.tsx
+++ b/packages/TorneloScoresheet/src/components/MoveTable/MoveRow.tsx
@@ -9,36 +9,57 @@ import { colours, ColourType } from '../../style/colour';
 export type MoveRowProps = {
   move: Move;
   moveNumber: number;
+  positionOccurance: Record<string, number>;
 };
-const highlightColorForPly = (ply?: ChessPly): ColourType | undefined => {
-  if (!ply) {
+
+const MoveRow: React.FC<MoveRowProps> = ({
+  move,
+  moveNumber,
+  positionOccurance,
+}) => {
+  const getPositionOccurance = (fen: string): number => {
+    let key = fen.split('-')[0]?.concat('-') ?? '';
+    console.log(key);
+    if (positionOccurance[key]) {
+      console.log(positionOccurance[key]);
+      return positionOccurance[key] || 0;
+    }
+    return 0;
+  };
+
+  const highlightColorForPly = (ply?: ChessPly): ColourType | undefined => {
+    if (!ply) {
+      return undefined;
+    }
+
+    if (ply.legality?.inCheckmate) {
+      return colours.lightOrange;
+    }
+
+    if (ply.legality?.inFiveFoldRepetition) {
+      return colours.darkBlue;
+    }
+
+    if (ply.legality?.inStalemate) {
+      return colours.lightGrey;
+    }
+
+    if (ply.legality?.inDraw) {
+      return colours.tertiary;
+    }
+
+    if (ply.legality?.inThreefoldRepetition) {
+      return colours.darkBlue;
+    }
+
+    if (getPositionOccurance(ply.startingFen)) {
+      if (getPositionOccurance(ply.startingFen) >= 3) {
+        return colours.lightGreen;
+      }
+    }
+
     return undefined;
-  }
-
-  if (ply.legality?.inCheckmate) {
-    return colours.lightOrange;
-  }
-
-  if (ply.legality?.inFiveFoldRepetition) {
-    return colours.darkBlue;
-  }
-
-  if (ply.legality?.inStalemate) {
-    return colours.lightGrey;
-  }
-
-  if (ply.legality?.inDraw) {
-    return colours.tertiary;
-  }
-
-  if (ply.legality?.inThreefoldRepetition) {
-    return colours.darkBlue;
-  }
-
-  return undefined;
-};
-
-const MoveRow: React.FC<MoveRowProps> = ({ move, moveNumber }) => {
+  };
   return (
     <View
       style={[

--- a/packages/TorneloScoresheet/src/components/MoveTable/MoveRow.tsx
+++ b/packages/TorneloScoresheet/src/components/MoveTable/MoveRow.tsx
@@ -10,26 +10,42 @@ export type MoveRowProps = {
   move: Move;
   moveNumber: number;
   positionOccurance: Record<string, number>;
+  onCellSelect: (fen: string) => void;
+  selectedFen: string | undefined;
 };
 
 const MoveRow: React.FC<MoveRowProps> = ({
   move,
   moveNumber,
   positionOccurance,
+  onCellSelect,
+  selectedFen,
 }) => {
   const getPositionOccurance = (fen: string): number => {
     let key = fen.split('-')[0]?.concat('-') ?? '';
-    console.log(key);
     if (positionOccurance[key]) {
-      console.log(positionOccurance[key]);
       return positionOccurance[key] || 0;
     }
     return 0;
   };
 
+  const fensSame = (fen: string, plyFen: string): boolean => {
+    let shortFenfromPly = plyFen.split('-')[0]?.concat('-') ?? '';
+    if (fen === shortFenfromPly) {
+      return true;
+    }
+    return false;
+  };
+
   const highlightColorForPly = (ply?: ChessPly): ColourType | undefined => {
     if (!ply) {
       return undefined;
+    }
+
+    if (selectedFen) {
+      if (fensSame(selectedFen, ply.startingFen)) {
+        return colours.lightGreen;
+      }
     }
 
     if (ply.legality?.inCheckmate) {
@@ -51,12 +67,13 @@ const MoveRow: React.FC<MoveRowProps> = ({
     if (ply.legality?.inThreefoldRepetition) {
       return colours.darkBlue;
     }
-
+    /*
     if (getPositionOccurance(ply.startingFen)) {
       if (getPositionOccurance(ply.startingFen) >= 3) {
         return colours.lightGreen;
       }
     }
+    */
 
     return undefined;
   };
@@ -78,11 +95,12 @@ const MoveRow: React.FC<MoveRowProps> = ({
         <MoveCell
           ply={move.white}
           highlightColor={highlightColorForPly(move.white)}
+          onCellSelect={onCellSelect}
         />
         <MoveCell
           ply={move.black}
           highlightColor={highlightColorForPly(move.black)}
-        />
+          onCellSelect={onCellSelect}></MoveCell>
       </View>
     </View>
   );

--- a/packages/TorneloScoresheet/src/components/MoveTable/MoveRow.tsx
+++ b/packages/TorneloScoresheet/src/components/MoveTable/MoveRow.tsx
@@ -5,11 +5,11 @@ import { styles } from './style';
 import MoveCell from './MoveCell';
 import { ChessPly, Move } from '../../types/ChessMove';
 import { colours, ColourType } from '../../style/colour';
+import { getShortFenAfterMove } from '../../util/moves';
 
 export type MoveRowProps = {
   move: Move;
   moveNumber: number;
-  positionOccurance: Record<string, number>;
   onCellSelect: (fen: string) => void;
   selectedFen: string | undefined;
 };
@@ -17,20 +17,13 @@ export type MoveRowProps = {
 const MoveRow: React.FC<MoveRowProps> = ({
   move,
   moveNumber,
-  positionOccurance,
   onCellSelect,
   selectedFen,
 }) => {
-  const getPositionOccurance = (fen: string): number => {
-    let key = fen.split('-')[0]?.concat('-') ?? '';
-    if (positionOccurance[key]) {
-      return positionOccurance[key] || 0;
-    }
-    return 0;
-  };
+  const fensSameAfterMove = (fen: string, ply: ChessPly): boolean => {
+    let shortFenfromPly = getShortFenAfterMove(ply);
 
-  const fensSame = (fen: string, plyFen: string): boolean => {
-    let shortFenfromPly = plyFen.split('-')[0]?.concat('-') ?? '';
+    //compare fens
     if (fen === shortFenfromPly) {
       return true;
     }
@@ -43,7 +36,7 @@ const MoveRow: React.FC<MoveRowProps> = ({
     }
 
     if (selectedFen) {
-      if (fensSame(selectedFen, ply.startingFen)) {
+      if (fensSameAfterMove(selectedFen, ply)) {
         return colours.lightGreen;
       }
     }
@@ -67,13 +60,6 @@ const MoveRow: React.FC<MoveRowProps> = ({
     if (ply.legality?.inThreefoldRepetition) {
       return colours.darkBlue;
     }
-    /*
-    if (getPositionOccurance(ply.startingFen)) {
-      if (getPositionOccurance(ply.startingFen) >= 3) {
-        return colours.lightGreen;
-      }
-    }
-    */
 
     return undefined;
   };

--- a/packages/TorneloScoresheet/src/components/MoveTable/MoveTable.tsx
+++ b/packages/TorneloScoresheet/src/components/MoveTable/MoveTable.tsx
@@ -8,9 +8,16 @@ import MoveRow from './MoveRow';
 export type MoveTableProps = {
   moves: ChessPly[];
   positionOccurance: Record<string, number>;
+  onCellSelect: (fen: string) => void;
+  selectedFen: string | undefined;
 };
 
-const MoveTable: React.FC<MoveTableProps> = ({ moves, positionOccurance }) => {
+const MoveTable: React.FC<MoveTableProps> = ({
+  moves,
+  positionOccurance,
+  onCellSelect,
+  selectedFen,
+}) => {
   return (
     <ScrollView style={styles.movesContainer}>
       {plysToMoves(moves).map((move, index) => (
@@ -19,6 +26,8 @@ const MoveTable: React.FC<MoveTableProps> = ({ moves, positionOccurance }) => {
           move={move}
           moveNumber={index + 1}
           positionOccurance={positionOccurance}
+          onCellSelect={onCellSelect}
+          selectedFen={selectedFen}
         />
       ))}
     </ScrollView>

--- a/packages/TorneloScoresheet/src/components/MoveTable/MoveTable.tsx
+++ b/packages/TorneloScoresheet/src/components/MoveTable/MoveTable.tsx
@@ -7,13 +7,19 @@ import MoveRow from './MoveRow';
 
 export type MoveTableProps = {
   moves: ChessPly[];
+  positionOccurance: Record<string, number>;
 };
 
-const MoveTable: React.FC<MoveTableProps> = ({ moves }) => {
+const MoveTable: React.FC<MoveTableProps> = ({ moves, positionOccurance }) => {
   return (
     <ScrollView style={styles.movesContainer}>
       {plysToMoves(moves).map((move, index) => (
-        <MoveRow key={index} move={move} moveNumber={index + 1} />
+        <MoveRow
+          key={index}
+          move={move}
+          moveNumber={index + 1}
+          positionOccurance={positionOccurance}
+        />
       ))}
     </ScrollView>
   );

--- a/packages/TorneloScoresheet/src/components/MoveTable/MoveTable.tsx
+++ b/packages/TorneloScoresheet/src/components/MoveTable/MoveTable.tsx
@@ -7,14 +7,12 @@ import MoveRow from './MoveRow';
 
 export type MoveTableProps = {
   moves: ChessPly[];
-  positionOccurance: Record<string, number>;
   onCellSelect: (fen: string) => void;
   selectedFen: string | undefined;
 };
 
 const MoveTable: React.FC<MoveTableProps> = ({
   moves,
-  positionOccurance,
   onCellSelect,
   selectedFen,
 }) => {
@@ -25,7 +23,6 @@ const MoveTable: React.FC<MoveTableProps> = ({
           key={index}
           move={move}
           moveNumber={index + 1}
-          positionOccurance={positionOccurance}
           onCellSelect={onCellSelect}
           selectedFen={selectedFen}
         />

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/ArbiterRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/ArbiterRecording.tsx
@@ -31,6 +31,16 @@ const ArbiterRecording: React.FC = () => {
     });
   };
 
+  const getPositionOccurance = (fen: string): number => {
+    if (!recordingMode) {
+      return 0;
+    }
+    if (recordingMode.pairing.positionOccurances[fen]) {
+      return recordingMode.pairing.positionOccurances[fen] || 0;
+    }
+    return 0;
+  };
+
   const selectFen = (fen: string): void => {
     let shortFen = fen.split('-')[0]?.concat('-') ?? '';
     if (shortFen === selectedFen) {
@@ -38,7 +48,15 @@ const ArbiterRecording: React.FC = () => {
       setSelectedFen(undefined);
       return;
     }
-    setSelectedFen(shortFen);
+    if (getPositionOccurance(shortFen)) {
+      if (getPositionOccurance(shortFen) >= 3) {
+        //only fens with 3 or more fold repetition can be selected
+        setSelectedFen(shortFen);
+        return;
+      }
+    }
+
+    setSelectedFen(undefined);
   };
 
   return (
@@ -59,7 +77,6 @@ const ArbiterRecording: React.FC = () => {
 
           <MoveTable
             moves={propagateRepetitions(recordingMode.moveHistory)}
-            positionOccurance={recordingMode.pairing.positionOccurances}
             onCellSelect={selectFen}
             selectedFen={selectedFen}
           />

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/ArbiterRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/ArbiterRecording.tsx
@@ -44,7 +44,10 @@ const ArbiterRecording: React.FC = () => {
             />
           </View>
 
-          <MoveTable moves={propagateRepetitions(recordingMode.moveHistory)} />
+          <MoveTable
+            moves={propagateRepetitions(recordingMode.moveHistory)}
+            positionOccurance={recordingMode.pairing.positionOccurances}
+          />
         </View>
       )}
     </>

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/ArbiterRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/ArbiterRecording.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { View } from 'react-native';
 import GraphicalModePlayerCard from '../../components/GraphicalModePlayerCard/GraphicalModePlayerCard';
 import { useArbiterRecordingState } from '../../context/AppModeStateContext';
@@ -8,6 +8,8 @@ import { ChessPly } from '../../types/ChessMove';
 
 const ArbiterRecording: React.FC = () => {
   const recordingModeState = useArbiterRecordingState();
+  const [selectedFen, setSelectedFen] = useState<string | undefined>(undefined);
+
   const recordingMode = recordingModeState?.[0];
   const propagateRepetitions = (moves: ChessPly[]): ChessPly[] => {
     const repetition = moves
@@ -28,6 +30,17 @@ const ArbiterRecording: React.FC = () => {
       return { ...move };
     });
   };
+
+  const selectFen = (fen: string): void => {
+    let shortFen = fen.split('-')[0]?.concat('-') ?? '';
+    if (shortFen === selectedFen) {
+      //unselct
+      setSelectedFen(undefined);
+      return;
+    }
+    setSelectedFen(shortFen);
+  };
+
   return (
     <>
       {recordingMode && (
@@ -47,6 +60,8 @@ const ArbiterRecording: React.FC = () => {
           <MoveTable
             moves={propagateRepetitions(recordingMode.moveHistory)}
             positionOccurance={recordingMode.pairing.positionOccurances}
+            onCellSelect={selectFen}
+            selectedFen={selectedFen}
           />
         </View>
       )}

--- a/packages/TorneloScoresheet/src/util/moves.ts
+++ b/packages/TorneloScoresheet/src/util/moves.ts
@@ -1,3 +1,4 @@
+import { chessEngine } from '../chessEngine/chessEngineInterface';
 import { PlayerColour } from '../types/ChessGameInfo';
 import { ChessPly, Move, PlyTypes } from '../types/ChessMove';
 
@@ -10,6 +11,31 @@ export const moveString = (ply: ChessPly, isEditing: boolean): string => {
   }
 
   return ply.san;
+};
+
+export const getShortFenAfterMove = (ply: ChessPly): string => {
+  let plyFen = ply.startingFen;
+  if ('move' in ply) {
+    //move was not a skip, process the move to get the fen post-move
+    const moveResult = chessEngine.makeMove(
+      ply.startingFen,
+      ply.move,
+      ply.promotion,
+    );
+
+    if (!moveResult) {
+      return plyFen;
+    }
+
+    const [moveFEN] = moveResult;
+    plyFen = moveFEN;
+  } else {
+    plyFen = chessEngine.skipTurn(ply.startingFen);
+  }
+
+  //shorten Fen
+  let shortFenfromPly = plyFen.split('-')[0]?.concat('-') ?? '';
+  return shortFenfromPly;
 };
 
 // Utility function to take a list of ply, and return a list of moves


### PR DESCRIPTION
This PR enables an arbiter to check which specific moves are causing a 3+ fold repetition. When the arbiter presses a move in arbiter recording mode that is in 3+ fold repetition, the other moves where this exact position occurred get highlighted in the table. Clicking again (on that cell or any other) will un-highlight the selection. 

https://user-images.githubusercontent.com/41656704/194037877-2e8abfe5-78ba-48bc-967f-e97e3bb2a2af.mp4

