### PR TITLE
Do nothing if player drops piece in it's origin square

### DIFF
--- a/packages/TorneloScoresheet/src/components/ChessBoard/ChessBoard.tsx
+++ b/packages/TorneloScoresheet/src/components/ChessBoard/ChessBoard.tsx
@@ -79,6 +79,13 @@ const ChessBoard: React.FC<ChessBoardProps> = ({
     return (col + row) % 2 === 0 ? colours.darkBlue : colours.lightBlue;
   };
 
+  const handleDrop = async (from: Position, to: Position): Promise<void> => {
+    if (from === to) {
+      return;
+    }
+    onMove({ from, to });
+  };
+
   return (
     <DragAndDropContextProvider>
       <RoundedView style={styles.board}>
@@ -101,7 +108,7 @@ const ChessBoard: React.FC<ChessBoardProps> = ({
             return (
               <DropTarget
                 onDrop={(data: unknown) =>
-                  onMove({ from: data as Position, to: square.position })
+                  handleDrop(data as Position, square.position)
                 }
                 key={rowIndex}
                 style={[


### PR DESCRIPTION
Previously we would try and make a move, which obviously wouldn't work, since you can't move a piece from and to the same square in chess.

This fixes a bug where we show an error message if the user changes their mind about moving a piece