### PR TITLE
Highlight repeated move cells in Arbiter table (if final move is repeated) 

### DIFF
--- a/packages/TorneloScoresheet/src/components/MoveTable/MoveRow.tsx
+++ b/packages/TorneloScoresheet/src/components/MoveTable/MoveRow.tsx
@@ -5,22 +5,29 @@ import { styles } from './style';
 import MoveCell from './MoveCell';
 import { ChessPly, Move } from '../../types/ChessMove';
 import { colours, ColourType } from '../../style/colour';
+import { getShortFenAfterMove } from '../../util/moves';
 
 export type MoveRowProps = {
   move: Move;
   moveNumber: number;
+  repeatedFenToHighlight: String;
 };
-const highlightColorForPly = (ply?: ChessPly): ColourType | undefined => {
+const highlightColorForPly = (
+  ply?: ChessPly,
+  repeatedFenToHighlight?: String,
+): ColourType | undefined => {
   if (!ply) {
     return undefined;
   }
 
-  if (ply.legality?.inCheckmate) {
-    return colours.lightOrange;
+  if (repeatedFenToHighlight) {
+    if (repeatedFenToHighlight === getShortFenAfterMove(ply)) {
+      return colours.darkBlue;
+    }
   }
 
-  if (ply.legality?.inFiveFoldRepetition) {
-    return colours.darkBlue;
+  if (ply.legality?.inCheckmate) {
+    return colours.lightOrange;
   }
 
   if (ply.legality?.inStalemate) {
@@ -31,14 +38,14 @@ const highlightColorForPly = (ply?: ChessPly): ColourType | undefined => {
     return colours.tertiary;
   }
 
-  if (ply.legality?.inThreefoldRepetition) {
-    return colours.darkBlue;
-  }
-
   return undefined;
 };
 
-const MoveRow: React.FC<MoveRowProps> = ({ move, moveNumber }) => {
+const MoveRow: React.FC<MoveRowProps> = ({
+  move,
+  moveNumber,
+  repeatedFenToHighlight,
+}) => {
   return (
     <View
       style={[
@@ -56,11 +63,17 @@ const MoveRow: React.FC<MoveRowProps> = ({ move, moveNumber }) => {
       <View style={styles.moveDetailsContainer}>
         <MoveCell
           ply={move.white}
-          highlightColor={highlightColorForPly(move.white)}
+          highlightColor={highlightColorForPly(
+            move.white,
+            repeatedFenToHighlight,
+          )}
         />
         <MoveCell
           ply={move.black}
-          highlightColor={highlightColorForPly(move.black)}
+          highlightColor={highlightColorForPly(
+            move.black,
+            repeatedFenToHighlight,
+          )}
         />
       </View>
     </View>

--- a/packages/TorneloScoresheet/src/components/MoveTable/MoveTable.tsx
+++ b/packages/TorneloScoresheet/src/components/MoveTable/MoveTable.tsx
@@ -7,13 +7,22 @@ import MoveRow from './MoveRow';
 
 export type MoveTableProps = {
   moves: ChessPly[];
+  repeatedFenToHighlight: String;
 };
 
-const MoveTable: React.FC<MoveTableProps> = ({ moves }) => {
+const MoveTable: React.FC<MoveTableProps> = ({
+  moves,
+  repeatedFenToHighlight,
+}) => {
   return (
     <ScrollView style={styles.movesContainer}>
       {plysToMoves(moves).map((move, index) => (
-        <MoveRow key={index} move={move} moveNumber={index + 1} />
+        <MoveRow
+          key={index}
+          move={move}
+          moveNumber={index + 1}
+          repeatedFenToHighlight={repeatedFenToHighlight}
+        />
       ))}
     </ScrollView>
   );

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/ArbiterRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/ArbiterRecording.tsx
@@ -5,6 +5,7 @@ import { useArbiterRecordingState } from '../../context/AppModeStateContext';
 import { styles } from './style';
 import MoveTable from '../../components/MoveTable/MoveTable';
 import { ChessPly } from '../../types/ChessMove';
+import { getShortFenAfterMove } from '../../util/moves';
 
 const ArbiterRecording: React.FC = () => {
   const recordingModeState = useArbiterRecordingState();
@@ -28,6 +29,23 @@ const ArbiterRecording: React.FC = () => {
       return { ...move };
     });
   };
+
+  const getFenOfLastRepetition = (): String => {
+    if (!recordingMode) {
+      return '';
+    }
+    if (
+      !recordingMode.moveHistory[recordingMode.moveHistory.length - 1]?.legality
+        ?.inThreefoldRepetition
+    ) {
+      return '';
+    }
+    return getShortFenAfterMove(
+      recordingMode.moveHistory[
+        recordingMode.moveHistory.length - 1
+      ] as ChessPly,
+    );
+  };
   return (
     <>
       {recordingMode && (
@@ -44,7 +62,10 @@ const ArbiterRecording: React.FC = () => {
             />
           </View>
 
-          <MoveTable moves={propagateRepetitions(recordingMode.moveHistory)} />
+          <MoveTable
+            moves={propagateRepetitions(recordingMode.moveHistory)}
+            repeatedFenToHighlight={getFenOfLastRepetition()}
+          />
         </View>
       )}
     </>

--- a/packages/TorneloScoresheet/src/util/moves.ts
+++ b/packages/TorneloScoresheet/src/util/moves.ts
@@ -1,3 +1,4 @@
+import { chessEngine } from '../chessEngine/chessEngineInterface';
 import { PlayerColour } from '../types/ChessGameInfo';
 import { ChessPly, Move, PlyTypes } from '../types/ChessMove';
 
@@ -22,3 +23,28 @@ export const plysToMoves = (ply: ChessPly[]): Move[] =>
       .slice(0, -1)
       .concat({ white: acc[acc.length - 1]!.white, black: el });
   }, [] as Move[]);
+
+export const getShortFenAfterMove = (ply: ChessPly): string => {
+  let plyFen = ply.startingFen;
+  if ('move' in ply) {
+    //move was not a skip, process the move to get the fen post-move
+    const moveResult = chessEngine.makeMove(
+      ply.startingFen,
+      ply.move,
+      ply.promotion,
+    );
+
+    if (!moveResult) {
+      return plyFen;
+    }
+
+    const [moveFEN] = moveResult;
+    plyFen = moveFEN;
+  } else {
+    plyFen = chessEngine.skipTurn(ply.startingFen);
+  }
+
+  //shorten Fen
+  let shortFenfromPly = plyFen.split('-')[0]?.concat('-') ?? '';
+  return shortFenfromPly;
+};


### PR DESCRIPTION
Highlights last cell in Arbiter recording mode table if it's in 3+ repetition, plus all other moves that are of the same fen after the move. 

https://user-images.githubusercontent.com/41656704/195847150-0e4b9bef-9d9a-4cc0-8bec-88ac85595a37.mp4

