### PR TITLE
Arbiter needs a way to load a different game without entering a result

### DIFF
--- a/packages/TorneloScoresheet/package-lock.json
+++ b/packages/TorneloScoresheet/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "torneloscoresheet",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "torneloscoresheet",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^1.17.3",
         "axios": "^0.26.1",

--- a/packages/TorneloScoresheet/src/components/Toolbar/ArbiterAndPlayerModeDisplay.tsx
+++ b/packages/TorneloScoresheet/src/components/Toolbar/ArbiterAndPlayerModeDisplay.tsx
@@ -72,6 +72,7 @@ const ArbiterAndPlayerModeDisplay: React.FC<
     }
     return 'Placeholder';
   };
+
   const handlePlayerPress = () => {
     //go back to player mode
     appModePlayerTransition[appModeState.mode]();

--- a/packages/TorneloScoresheet/src/components/Toolbar/Toolbar.tsx
+++ b/packages/TorneloScoresheet/src/components/Toolbar/Toolbar.tsx
@@ -50,6 +50,14 @@ const Toolbar: React.FC = () => {
                 colour="black"
               />
             )}
+            {viewModel?.goToPairingSelection && (
+              <IconButton
+                icon="arrow-back"
+                label="Back"
+                onPress={viewModel.goToPairingSelection}
+                colour="black"
+              />
+            )}
             {viewModel?.goToViewPastGames && (
               <IconButton
                 icon="history"

--- a/packages/TorneloScoresheet/src/components/Toolbar/Toolbar.tsx
+++ b/packages/TorneloScoresheet/src/components/Toolbar/Toolbar.tsx
@@ -11,6 +11,7 @@ import { useToolbar } from '../../context/AppModeStateContext';
 import ArbiterAndPlayerModeDisplay from './ArbiterAndPlayerModeDisplay';
 import packageJson from '../../../package.json';
 import Help from '../Help/Help';
+import OptionSheet from '../OptionSheet/OptionSheet';
 /**
  * The App's toolbar.
  *
@@ -21,9 +22,16 @@ import Help from '../Help/Help';
 const Toolbar: React.FC = () => {
   const viewModel = useToolbar();
   const [showSheet, setShowSheet] = useState(false);
+  const [showConfirmBack, setShowConfirmBack] = useState(false);
 
   const handleHelpPress = () => {
     setShowSheet((a: any) => !a);
+  };
+
+  const handleBackPress = () => {
+    if (!viewModel || !viewModel.goToPairingSelection) return;
+    setShowConfirmBack(false);
+    viewModel.goToPairingSelection();
   };
 
   return (
@@ -36,6 +44,17 @@ const Toolbar: React.FC = () => {
           visible={showSheet}>
           <Help onDone={() => setShowSheet(false)} />
         </Sheet>
+        <OptionSheet
+          message={`Confirm Game Exit`}
+          onCancel={() => setShowConfirmBack(false)}
+          options={[
+            {
+              text: 'Confirm',
+              onPress: handleBackPress,
+            },
+          ]}
+          visible={showConfirmBack}
+        />
         <View
           style={[
             styles.container,
@@ -66,7 +85,7 @@ const Toolbar: React.FC = () => {
               <IconButton
                 icon="arrow-back"
                 label="Back"
-                onPress={viewModel.goToPairingSelection}
+                onPress={() => setShowConfirmBack(true)}
                 colour="black"
               />
             )}

--- a/packages/TorneloScoresheet/src/components/Toolbar/Toolbar.tsx
+++ b/packages/TorneloScoresheet/src/components/Toolbar/Toolbar.tsx
@@ -50,14 +50,6 @@ const Toolbar: React.FC = () => {
                 colour="black"
               />
             )}
-            {viewModel?.goToPairingSelection && (
-              <IconButton
-                icon="arrow-back"
-                label="Back"
-                onPress={viewModel.goToPairingSelection}
-                colour="black"
-              />
-            )}
             {viewModel?.goToViewPastGames && (
               <IconButton
                 icon="history"
@@ -68,6 +60,16 @@ const Toolbar: React.FC = () => {
             <ArbiterAndPlayerModeDisplay
               currentTextColour={viewModel.currentTextColour}
             />
+          </View>
+          <View style={styles.backArrow}>
+            {viewModel?.goToPairingSelection && (
+              <IconButton
+                icon="arrow-back"
+                label="Back"
+                onPress={viewModel.goToPairingSelection}
+                colour="black"
+              />
+            )}
           </View>
           <View style={styles.logo}>
             <Image

--- a/packages/TorneloScoresheet/src/components/Toolbar/style.ts
+++ b/packages/TorneloScoresheet/src/components/Toolbar/style.ts
@@ -53,4 +53,7 @@ export const styles = StyleSheet.create({
     flex: 1,
   },
   versionContainer: { marginLeft: 6, marginTop: 6 },
+  backArrow: {
+    flex: 7,
+  },
 });

--- a/packages/TorneloScoresheet/src/hooks/appMode/toolbarViewModel.ts
+++ b/packages/TorneloScoresheet/src/hooks/appMode/toolbarViewModel.ts
@@ -2,10 +2,13 @@ import { useContext } from 'react';
 import { AppModeStateContextType } from '../../context/AppModeStateContext';
 import { colours, ColourType, textColour } from '../../style/colour';
 import { AppMode, isArbiterMode } from '../../types/AppModeState';
+import { Result, succ } from '../../types/Result';
+import { getStoredPairingList } from '../../util/storage';
 
 type ToolbarViewModel = {
   goToEnterPgn: (() => void) | undefined;
   goToViewPastGames: (() => void) | undefined;
+  goToPairingSelection: (() => void) | undefined;
   currentColour: ColourType;
   currentTextColour: string;
 };
@@ -32,6 +35,21 @@ export const makeToolbarViewModel =
       });
     };
 
+    const goToPairingSelection = async (): Promise<Result<string>> => {
+      const pairings = await getStoredPairingList();
+
+      if (pairings === null) {
+        return fail('Error loading pairings.');
+      }
+
+      setAppModeState({
+        mode: AppMode.PairingSelection,
+        pairings,
+        games: pairings.length,
+      });
+      return succ('');
+    };
+
     const currentColour = colourForMode(appModeState.mode);
 
     return {
@@ -39,6 +57,10 @@ export const makeToolbarViewModel =
         appModeState.mode !== AppMode.ViewPastGames ? undefined : goToEnterPgn,
       goToViewPastGames:
         appModeState.mode !== AppMode.EnterPgn ? undefined : goToViewPastGames,
+      goToPairingSelection:
+        appModeState.mode !== AppMode.ArbiterRecording
+          ? undefined
+          : goToPairingSelection,
       currentColour,
       currentTextColour: textColour(currentColour),
     };


### PR DESCRIPTION
Previously, if an arbiter wanted to select a different game they would have to enter a game result and go back from result mode. This allows them to return to pairing selection directly from recording mode. 

https://user-images.githubusercontent.com/64511606/195967565-50053a18-b4e2-4367-84b0-e36bbeb03acb.mp4

