### PR TITLE
Fix fen position occurence counting

### DIFF
--- a/packages/TorneloScoresheet/__tests__/useEditMoveState.test.ts
+++ b/packages/TorneloScoresheet/__tests__/useEditMoveState.test.ts
@@ -71,9 +71,9 @@ describe('Edit Move With Skip Ply', () => {
         pairing: {
           ...editMoveState.pairing,
           positionOccurances: {
-            'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -': 1,
-            'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq -': 1,
-            'rnbqkbnr/ppppppp1/7p/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -': 1,
+            'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w': 1,
+            'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b': 1,
+            'rnbqkbnr/ppppppp1/7p/8/8/8/PPPPPPPP/RNBQKBNR w': 1,
           },
         },
         board: chessEngine.fenToBoardPositions(
@@ -199,10 +199,10 @@ describe('Edit Move With Skip Ply', () => {
         pairing: {
           ...editMoveState.pairing,
           positionOccurances: {
-            'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -': 1,
-            'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b KQkq -': 1,
-            'rnbqkbnr/ppppppp1/7p/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -': 1,
-            'rnbqkbnr/ppppppp1/7p/8/8/8/PPPPPPPP/RNBQKBNR b KQkq -': 1,
+            'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w': 1,
+            'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR b': 1,
+            'rnbqkbnr/ppppppp1/7p/8/8/8/PPPPPPPP/RNBQKBNR w': 1,
+            'rnbqkbnr/ppppppp1/7p/8/8/8/PPPPPPPP/RNBQKBNR b': 1,
           },
         },
         board: chessEngine.fenToBoardPositions(
@@ -332,9 +332,9 @@ describe('Edit move with Move Ply', () => {
         pairing: {
           ...editMoveState.pairing,
           positionOccurances: {
-            'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -': 1,
-            'rnbqkbnr/pppppppp/8/8/8/P7/1PPPPPPP/RNBQKBNR b KQkq -': 1,
-            'rnbqkbnr/ppppppp1/7p/8/8/P7/1PPPPPPP/RNBQKBNR w KQkq -': 1,
+            'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w': 1,
+            'rnbqkbnr/pppppppp/8/8/8/P7/1PPPPPPP/RNBQKBNR b': 1,
+            'rnbqkbnr/ppppppp1/7p/8/8/P7/1PPPPPPP/RNBQKBNR w': 1,
           },
         },
         board: chessEngine.fenToBoardPositions(

--- a/packages/TorneloScoresheet/__tests__/useRecordingModeState.test.ts
+++ b/packages/TorneloScoresheet/__tests__/useRecordingModeState.test.ts
@@ -1840,12 +1840,6 @@ describe('Move Legality Checking', () => {
     ] as ChessPly[];
 
     const recordingState = generateRecordingState(moveHistory, 'Graphical');
-    recordingState.pairing.positionOccurances = {
-      'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -': 2,
-      'rnbqkbnr/pppppppp/8/8/8/5N2/PPPPPPPP/RNBQKB1R b KQkq -': 2,
-      'rnbqkb1r/pppppppp/5n2/8/8/5N2/PPPPPPPP/RNBQKB1R w KQkq -': 2,
-      'rnbqkb1r/pppppppp/5n2/8/8/8/PPPPPPPP/RNBQKBNR b KQkq -': 2,
-    };
     const setContextMock = mockAppModeContext(recordingState);
     const move = { from: 'g1', to: 'f3' };
     const recordingStateHook = renderCustomHook(useRecordingState);
@@ -2383,12 +2377,6 @@ describe('Move Legality Checking', () => {
       },
     ] as ChessPly[];
     const recordingState = generateRecordingState(moveHistory, 'Graphical');
-    recordingState.pairing.positionOccurances = {
-      'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq -': 5,
-      'rnbqkbnr/pppppppp/8/8/8/5N2/PPPPPPPP/RNBQKB1R b KQkq -': 4,
-      'rnbqkb1r/pppppppp/5n2/8/8/5N2/PPPPPPPP/RNBQKB1R w KQkq -': 4,
-      'rnbqkb1r/pppppppp/5n2/8/8/8/PPPPPPPP/RNBQKBNR b KQkq -': 4,
-    };
     const setContextMock = mockAppModeContext(recordingState);
     const move = { from: 'g8', to: 'f6' };
     const recordingStateHook = renderCustomHook(useRecordingState);

--- a/packages/TorneloScoresheet/src/chessEngine/chessTsChessEngine.ts
+++ b/packages/TorneloScoresheet/src/chessEngine/chessTsChessEngine.ts
@@ -20,6 +20,7 @@ import {
   SkipPly,
 } from '../types/ChessMove';
 import { Result, succ, fail, isError } from '../types/Result';
+import { getStateFromFen } from '../util/fen';
 import { ChessEngineInterface } from './chessEngineInterface';
 
 const PARSING_FAILURE = fail(
@@ -117,7 +118,7 @@ const gameInNFoldRepetition = (
   positionOccurence: Record<string, number>,
   n: number,
 ): boolean => {
-  const newFen = fen.split('-')[0]?.concat('-') ?? '';
+  const newFen = getStateFromFen(fen);
   return (positionOccurence[newFen] ?? 0) >= n;
 };
 

--- a/packages/TorneloScoresheet/src/hooks/appMode/editMoveState.ts
+++ b/packages/TorneloScoresheet/src/hooks/appMode/editMoveState.ts
@@ -12,6 +12,7 @@ import {
 } from '../../types/ChessMove';
 import { MoveLegality } from '../../types/MoveLegality';
 import { fail, Result, succ } from '../../types/Result';
+import { getStateFromFen } from '../../util/fen';
 import { getStoredRecordingModeData } from '../../util/storage';
 
 type editMoveStateHookType = {
@@ -206,7 +207,7 @@ const getOldPositionOccurences = (
 ): Record<string, number> => {
   const positionOccurences: Record<string, number> = {};
   moveHistory.forEach(move => {
-    const key = move.startingFen.split('-')[0]?.concat('-') ?? '';
+    const key = getStateFromFen(move.startingFen);
 
     positionOccurences[key] =
       key in positionOccurences ? (positionOccurences[key] || 0) + 1 : 1;
@@ -218,7 +219,7 @@ const updatePositionOccurence = (
   positionOccurences: Record<string, number>,
   fen: string,
 ): Record<string, number> => {
-  const key = fen.split('-')[0]?.concat('-') ?? '';
+  const key = getStateFromFen(fen);
 
   positionOccurences[key] =
     key in positionOccurences ? (positionOccurences[key] || 0) + 1 : 1;

--- a/packages/TorneloScoresheet/src/hooks/appMode/recordingState.ts
+++ b/packages/TorneloScoresheet/src/hooks/appMode/recordingState.ts
@@ -16,6 +16,7 @@ import { storeRecordingModeData } from '../../util/storage';
 import { MoveLegality } from '../../types/MoveLegality';
 import { AppModeStateContextType } from '../../context/AppModeStateContext';
 import { getCurrentFen } from '../../util/moveHistory';
+import { getStateFromFen } from '../../util/fen';
 
 export type MakeMoveResult = {
   didInsertSkip: boolean;
@@ -223,7 +224,7 @@ export const makeUseRecordingState =
     };
 
     const changePositionOccurance = (fen: string, change: number): void => {
-      const key = fen.split('-')[0]?.concat('-') ?? '';
+      const key = getStateFromFen(fen);
       if (!appModeState.pairing.positionOccurances) {
         appModeState.pairing.positionOccurances = {};
       }

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/ArbiterRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/ArbiterRecording.tsx
@@ -6,6 +6,7 @@ import { styles } from './style';
 import MoveTable from '../../components/MoveTable/MoveTable';
 import { ChessPly } from '../../types/ChessMove';
 import { getShortFenAfterMove } from '../../util/moves';
+import { getStateFromFen } from '../../util/fen';
 
 const ArbiterRecording: React.FC = () => {
   const recordingModeState = useArbiterRecordingState();
@@ -17,10 +18,10 @@ const ArbiterRecording: React.FC = () => {
           move.legality?.inFiveFoldRepetition ||
           move.legality?.inThreefoldRepetition,
       )
-      .map(move => move.startingFen.split('-')[0]?.concat('-') ?? '');
+      .map(move => getStateFromFen(move.startingFen));
 
     return moves.map(move => {
-      if ((move.startingFen.split('-')[0]?.concat('-') ?? '') in repetition) {
+      if (getStateFromFen(move.startingFen) in repetition) {
         return {
           ...move,
           legality: { ...move.legality, inFiveFoldRepetition: true },

--- a/packages/TorneloScoresheet/src/util/fen.ts
+++ b/packages/TorneloScoresheet/src/util/fen.ts
@@ -1,0 +1,19 @@
+/**
+ * Returns the board state section of a fen string
+ * @param fen the current fen
+ * @returns the state part of the fen or an empty string if the fen is invalid
+ */
+export const getStateFromFen = (fen: string): string => {
+  const regexResult =
+    /(?<boardState>.+\/.+\/.+\/.+\/.+\/.+\/.+\/.+?\s.{1})(?<game_state>\s.+?\s.+?\s.+?\s.+?)?/.exec(
+      fen,
+    );
+  if (
+    !regexResult ||
+    !regexResult.groups ||
+    !regexResult.groups['boardState']
+  ) {
+    return '';
+  }
+  return regexResult.groups['boardState'];
+};

--- a/packages/TorneloScoresheet/src/util/moves.ts
+++ b/packages/TorneloScoresheet/src/util/moves.ts
@@ -1,6 +1,7 @@
 import { chessEngine } from '../chessEngine/chessEngineInterface';
 import { PlayerColour } from '../types/ChessGameInfo';
 import { ChessPly, Move, PlyTypes } from '../types/ChessMove';
+import { getStateFromFen } from './fen';
 
 export const moveString = (ply: ChessPly, isEditing: boolean): string => {
   if (isEditing) {
@@ -45,6 +46,6 @@ export const getShortFenAfterMove = (ply: ChessPly): string => {
   }
 
   //shorten Fen
-  let shortFenfromPly = plyFen.split('-')[0]?.concat('-') ?? '';
+  let shortFenfromPly = getStateFromFen(plyFen);
   return shortFenfromPly;
 };

--- a/packages/TorneloScoresheet/testUtils/testUtils.ts
+++ b/packages/TorneloScoresheet/testUtils/testUtils.ts
@@ -11,6 +11,7 @@ import {
 } from '../src/types/AppModeState';
 import { ChessGameInfo, PlayerColour } from '../src/types/ChessGameInfo';
 import { ChessPly } from '../src/types/ChessMove';
+import { getStateFromFen } from '../src/util/fen';
 import * as Storage from '../src/util/storage';
 
 /**
@@ -76,7 +77,7 @@ export const generateRecordingState = (
 ): RecordingMode => {
   const positionOccurances: Record<string, number> = {};
   moveHistory.forEach(move => {
-    const key = move.startingFen.split('-')[0]?.concat('-') ?? '';
+    const key = getStateFromFen(move.startingFen);
     positionOccurances[key] =
       key in positionOccurances ? (positionOccurances[key] || 0) + 1 : 1;
   });
@@ -104,7 +105,7 @@ export const generateEditMoveState = (
 ): EditingMoveMode => {
   const positionOccurances: Record<string, number> = {};
   moveHistory.forEach(move => {
-    const key = move.startingFen.split('-')[0]?.concat('-') ?? '';
+    const key = getStateFromFen(move.startingFen);
     positionOccurances[key] =
       key in positionOccurances ? (positionOccurances[key] || 0) + 1 : 1;
   });


### PR DESCRIPTION
There was an issue with the way we were counting position occurences.
Basically, a fen is composed of multiple sections (https://en.wikipedia.org/wiki/Forsyth%E2%80%93Edwards_Notation)
We were splitting the fen by the '-' character, but this would break if an en passant square exists, then the '-' would not be in the fen.
This PR fixes this problem by introducing a fen util function called `getStateFromFen` which returns just the state of the board and whos turn it is from the fen, which is the only information we need to be counting position occurences