### PR TITLE
Standardise Arbiter Mode navigation

### DIFF
--- a/packages/TorneloScoresheet/src/components/OptionSheet/OptionSheet.tsx
+++ b/packages/TorneloScoresheet/src/components/OptionSheet/OptionSheet.tsx
@@ -7,7 +7,7 @@ import TextIconButton, {
   TextIconButtonProps,
 } from '../TextIconButton/TextIconButton';
 
-type Option = {
+export type Option = {
   icon?: React.FC<SvgProps>;
   text?: string;
   onPress: () => void;

--- a/packages/TorneloScoresheet/src/components/Toolbar/ArbiterModeNavigation.tsx
+++ b/packages/TorneloScoresheet/src/components/Toolbar/ArbiterModeNavigation.tsx
@@ -1,0 +1,137 @@
+import React, { useState } from 'react';
+import { View } from 'react-native';
+import {
+  useAppModeState,
+  useArbiterRecordingState,
+  useArbiterResultDisplayState,
+  useArbiterTablePairingState,
+  useEnterPgnState,
+  usePairingSelectionState,
+  useViewPastGames,
+} from '../../context/AppModeStateContext';
+import { AppMode } from '../../types/AppModeState';
+import IconButton from '../IconButton/IconButton';
+import OptionSheet, { Option } from '../OptionSheet/OptionSheet';
+import { styles } from './style';
+
+const ArbiterModeNavigation: React.FC = () => {
+  const appModeState = useAppModeState();
+
+  // determines if the navigation button should be shown for this app mode
+  const appModeArbiterNavigation: Record<AppMode, boolean> = {
+    // show arbiter navigation button
+    [AppMode.ArbiterRecording]: true,
+    [AppMode.ArbiterTablePairing]: true,
+    [AppMode.ArbiterResultDisplay]: true,
+    [AppMode.PairingSelection]: true,
+    [AppMode.ViewPastGames]: true,
+    [AppMode.EnterPgn]: true,
+
+    // do not show arbiter navigation button
+    [AppMode.ResultDisplay]: false,
+    [AppMode.TablePairing]: false,
+    [AppMode.EditMove]: false,
+    [AppMode.Recording]: false,
+  };
+
+  const makeNavigationOption = (
+    name: string,
+    transition: (() => void) | undefined,
+  ): Option => {
+    return {
+      text: name,
+      onPress: () => {
+        setShowNavigationSheet(false);
+        if (transition) {
+          transition();
+        }
+      },
+      style: {
+        width: 300,
+      },
+    };
+  };
+  const arbiterNavigationOptions: Record<AppMode, Option[]> = {
+    [AppMode.ResultDisplay]: [],
+    [AppMode.TablePairing]: [],
+    [AppMode.EditMove]: [],
+    [AppMode.Recording]: [],
+    [AppMode.EnterPgn]: [
+      makeNavigationOption('Past Games', useEnterPgnState()?.viewPastGames),
+    ],
+
+    [AppMode.ArbiterRecording]: [
+      makeNavigationOption(
+        'Enter Pgn',
+        useArbiterRecordingState()?.[1].goBackToEnterPgn,
+      ),
+      makeNavigationOption(
+        'Pairing Selection',
+        useArbiterRecordingState()?.[1].goBackToPairingSelection,
+      ),
+      makeNavigationOption(
+        'Table Pairing',
+        useArbiterRecordingState()?.[1].goBackToTablePairing,
+      ),
+    ],
+    [AppMode.ArbiterTablePairing]: [
+      makeNavigationOption(
+        'Enter Pgn',
+        useArbiterTablePairingState()?.[1].goBackToEnterPgn,
+      ),
+      makeNavigationOption(
+        'Pairing Selection',
+        useArbiterTablePairingState()?.[1].goBackToPairingSelectionMode,
+      ),
+    ],
+    [AppMode.ArbiterResultDisplay]: [
+      makeNavigationOption(
+        'Enter Pgn',
+        useArbiterResultDisplayState()?.[1].goBackToEnterPgn,
+      ),
+      makeNavigationOption(
+        'Scoresheet Recording',
+        useArbiterResultDisplayState()?.[1].goBackToRecordingMode,
+      ),
+      makeNavigationOption(
+        'Table Pairing',
+        useArbiterResultDisplayState()?.[1].goBackToPairingSelection,
+      ),
+    ],
+    [AppMode.PairingSelection]: [
+      makeNavigationOption(
+        'Enter Pgn',
+        usePairingSelectionState()?.[1].goToEnterPgn,
+      ),
+    ],
+    [AppMode.ViewPastGames]: [
+      makeNavigationOption('Enter Pgn', useViewPastGames()?.goToEnterPgn),
+    ],
+  };
+
+  const [showNavigationSheet, setShowNavigationSheet] = useState(false);
+
+  return (
+    <>
+      <OptionSheet
+        message="Change App Mode"
+        visible={showNavigationSheet}
+        options={arbiterNavigationOptions[appModeState.mode]}
+        onCancel={() => setShowNavigationSheet(false)}
+      />
+
+      {appModeArbiterNavigation[appModeState.mode] && (
+        <View style={styles.backArrow}>
+          <IconButton
+            icon="arrow-drop-down"
+            label=""
+            onPress={() => setShowNavigationSheet(true)}
+            colour="black"
+          />
+        </View>
+      )}
+    </>
+  );
+};
+
+export default ArbiterModeNavigation;

--- a/packages/TorneloScoresheet/src/components/Toolbar/Toolbar.tsx
+++ b/packages/TorneloScoresheet/src/components/Toolbar/Toolbar.tsx
@@ -11,7 +11,7 @@ import { useToolbar } from '../../context/AppModeStateContext';
 import ArbiterAndPlayerModeDisplay from './ArbiterAndPlayerModeDisplay';
 import packageJson from '../../../package.json';
 import Help from '../Help/Help';
-import OptionSheet from '../OptionSheet/OptionSheet';
+import ArbiterModeNavigation from './ArbiterModeNavigation';
 /**
  * The App's toolbar.
  *
@@ -22,16 +22,9 @@ import OptionSheet from '../OptionSheet/OptionSheet';
 const Toolbar: React.FC = () => {
   const viewModel = useToolbar();
   const [showSheet, setShowSheet] = useState(false);
-  const [showConfirmBack, setShowConfirmBack] = useState(false);
 
   const handleHelpPress = () => {
     setShowSheet((a: any) => !a);
-  };
-
-  const handleBackPress = () => {
-    if (!viewModel || !viewModel.goToPairingSelection) return;
-    setShowConfirmBack(false);
-    viewModel.goToPairingSelection();
   };
 
   return (
@@ -44,52 +37,19 @@ const Toolbar: React.FC = () => {
           visible={showSheet}>
           <Help onDone={() => setShowSheet(false)} />
         </Sheet>
-        <OptionSheet
-          message={`Confirm Game Exit`}
-          onCancel={() => setShowConfirmBack(false)}
-          options={[
-            {
-              text: 'Confirm',
-              onPress: handleBackPress,
-            },
-          ]}
-          visible={showConfirmBack}
-        />
         <View
           style={[
             styles.container,
             backgroundColorStyle(viewModel.currentColour),
           ]}>
           <View style={styles.arbiterLock}>
-            {viewModel?.goToEnterPgn && (
-              <IconButton
-                icon="arrow-back"
-                label="Back"
-                onPress={viewModel.goToEnterPgn}
-                colour="black"
-              />
-            )}
-            {viewModel?.goToViewPastGames && (
-              <IconButton
-                icon="history"
-                onPress={viewModel.goToViewPastGames}
-                colour="black"
-              />
-            )}
+            <ArbiterModeNavigation />
+
             <ArbiterAndPlayerModeDisplay
               currentTextColour={viewModel.currentTextColour}
             />
           </View>
-          <View style={styles.backArrow}>
-            {viewModel?.goToPairingSelection && (
-              <IconButton
-                icon="arrow-back"
-                label="Back"
-                onPress={() => setShowConfirmBack(true)}
-                colour="black"
-              />
-            )}
-          </View>
+
           <View style={styles.logo}>
             <Image
               style={styles.logoImage}
@@ -115,9 +75,7 @@ const Toolbar: React.FC = () => {
               />
             </View>
           </View>
-          <View style={styles.toggleToTextEntryModeButton}>
-            <ToggleRecordingMode />
-          </View>
+
           <IconButton
             icon="help"
             onPress={handleHelpPress}

--- a/packages/TorneloScoresheet/src/components/Toolbar/style.ts
+++ b/packages/TorneloScoresheet/src/components/Toolbar/style.ts
@@ -50,10 +50,11 @@ export const styles = StyleSheet.create({
     marginRight: 20,
   },
   arbiterLock: {
-    flex: 1,
+    display: 'flex',
+    flexDirection: 'row',
   },
   versionContainer: { marginLeft: 6, marginTop: 6 },
   backArrow: {
-    flex: 7,
+    marginRight: 30,
   },
 });

--- a/packages/TorneloScoresheet/src/hooks/appMode/arbiterRecordingState.ts
+++ b/packages/TorneloScoresheet/src/hooks/appMode/arbiterRecordingState.ts
@@ -1,11 +1,15 @@
 import { useContext } from 'react';
 import { AppModeStateContextType } from '../../context/AppModeStateContext';
 import { AppMode, ArbiterRecordingMode } from '../../types/AppModeState';
+import { getStoredPairingList } from '../../util/storage';
 
 type ArbiterRecordingStateHookType = [
   ArbiterRecordingMode,
   {
     goToRecordingMode: () => void;
+    goBackToEnterPgn: () => void;
+    goBackToPairingSelection: () => void;
+    goBackToTablePairing: () => void;
   },
 ];
 
@@ -26,5 +30,33 @@ export const makeUseArbiterRecordingState =
       });
     };
 
-    return [appModeState, { goToRecordingMode }];
+    const goBackToEnterPgn = () => {
+      setAppModeState({
+        mode: AppMode.EnterPgn,
+      });
+    };
+
+    const goBackToTablePairing = () => {
+      setAppModeState({
+        mode: AppMode.TablePairing,
+        pairing: appModeState.pairing,
+      });
+    };
+
+    const goBackToPairingSelection = async () => {
+      setAppModeState({
+        mode: AppMode.PairingSelection,
+        pairings: (await getStoredPairingList()) ?? [],
+      });
+    };
+
+    return [
+      appModeState,
+      {
+        goToRecordingMode,
+        goBackToEnterPgn,
+        goBackToTablePairing,
+        goBackToPairingSelection,
+      },
+    ];
   };

--- a/packages/TorneloScoresheet/src/hooks/appMode/arbiterResultDisplayState.ts
+++ b/packages/TorneloScoresheet/src/hooks/appMode/arbiterResultDisplayState.ts
@@ -6,6 +6,7 @@ import { PlayerColour } from '../../types/ChessGameInfo';
 import { ChessPly, PlyTypes } from '../../types/ChessMove';
 import { fail, Result, succ } from '../../types/Result';
 import {
+  getStoredPairingList,
   getStoredRecordingModeData,
   storeGameHistory,
 } from '../../util/storage';
@@ -15,6 +16,7 @@ type arbiterResultDisplayStateHookType = [
   {
     goToResultDisplayMode: () => void;
     goBackToEnterPgn: () => void;
+    goBackToPairingSelection: () => void;
     goBackToRecordingMode: () => Promise<Result<string>>;
   },
 ];
@@ -49,6 +51,12 @@ export const makeUseArbiterResultDisplayState =
       // set mode to enter pgn
       setAppModeState({
         mode: AppMode.EnterPgn,
+      });
+    };
+    const goBackToPairingSelection = async () => {
+      setAppModeState({
+        mode: AppMode.PairingSelection,
+        pairings: (await getStoredPairingList()) ?? [],
       });
     };
 
@@ -101,6 +109,11 @@ export const makeUseArbiterResultDisplayState =
 
     return [
       appModeState,
-      { goToResultDisplayMode, goBackToEnterPgn, goBackToRecordingMode },
+      {
+        goToResultDisplayMode,
+        goBackToEnterPgn,
+        goBackToRecordingMode,
+        goBackToPairingSelection,
+      },
     ];
   };

--- a/packages/TorneloScoresheet/src/hooks/appMode/toolbarViewModel.ts
+++ b/packages/TorneloScoresheet/src/hooks/appMode/toolbarViewModel.ts
@@ -2,13 +2,8 @@ import { useContext } from 'react';
 import { AppModeStateContextType } from '../../context/AppModeStateContext';
 import { colours, ColourType, textColour } from '../../style/colour';
 import { AppMode, isArbiterMode } from '../../types/AppModeState';
-import { Result, succ } from '../../types/Result';
-import { getStoredPairingList } from '../../util/storage';
 
 type ToolbarViewModel = {
-  goToEnterPgn: (() => void) | undefined;
-  goToViewPastGames: (() => void) | undefined;
-  goToPairingSelection: (() => void) | undefined;
   currentColour: ColourType;
   currentTextColour: string;
 };
@@ -18,49 +13,9 @@ export const makeToolbarViewModel =
   () => {
     const [appModeState, setAppModeState] = useContext(context);
 
-    const goToEnterPgn = () =>
-      setAppModeState(previous => {
-        if (previous.mode !== AppMode.ViewPastGames) {
-          return previous;
-        }
-        return { mode: AppMode.EnterPgn };
-      });
-
-    const goToViewPastGames = () => {
-      setAppModeState(previous => {
-        if (previous.mode !== AppMode.EnterPgn) {
-          return previous;
-        }
-        return { mode: AppMode.ViewPastGames };
-      });
-    };
-
-    const goToPairingSelection = async (): Promise<Result<string>> => {
-      const pairings = await getStoredPairingList();
-
-      if (pairings === null) {
-        return fail('Error loading pairings.');
-      }
-
-      setAppModeState({
-        mode: AppMode.PairingSelection,
-        pairings,
-        games: pairings.length,
-      });
-      return succ('');
-    };
-
     const currentColour = colourForMode(appModeState.mode);
 
     return {
-      goToEnterPgn:
-        appModeState.mode !== AppMode.ViewPastGames ? undefined : goToEnterPgn,
-      goToViewPastGames:
-        appModeState.mode !== AppMode.EnterPgn ? undefined : goToViewPastGames,
-      goToPairingSelection:
-        appModeState.mode !== AppMode.ArbiterRecording
-          ? undefined
-          : goToPairingSelection,
       currentColour,
       currentTextColour: textColour(currentColour),
     };

--- a/packages/TorneloScoresheet/src/pages/PairingSelection/PairingSelection.tsx
+++ b/packages/TorneloScoresheet/src/pages/PairingSelection/PairingSelection.tsx
@@ -55,11 +55,6 @@ const PairingSelection: React.FC = () => {
             />
           )}
           <View style={styles.headerRow}>
-            <PrimaryButton
-              style={styles.actionButton}
-              onPress={goToEnterPgn}
-              label="Back"
-            />
             <PrimaryText
               size={50}
               weight={FontWeight.SemiBold}

--- a/packages/TorneloScoresheet/src/pages/PairingSelection/style.ts
+++ b/packages/TorneloScoresheet/src/pages/PairingSelection/style.ts
@@ -11,10 +11,9 @@ export const styles = StyleSheet.create({
   },
   headerRow: {
     display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'flex-end',
-    width: '100%',
+    flexDirection: 'column',
+    alignItems: 'center',
+    textAlign: 'center',
   },
   boardPairingContainer: {
     marginBottom: 20,

--- a/packages/TorneloScoresheet/src/pages/ResultDisplay/ArbiterResultDisplay.tsx
+++ b/packages/TorneloScoresheet/src/pages/ResultDisplay/ArbiterResultDisplay.tsx
@@ -1,15 +1,11 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { View } from 'react-native';
-import OptionSheet from '../../components/OptionSheet/OptionSheet';
 import PlayerCard from '../../components/PlayerCard/PlayerCard';
-import PrimaryButton from '../../components/PrimaryButton/PrimaryButton';
 import PrimaryText, {
   FontWeight,
 } from '../../components/PrimaryText/PrimaryText';
 import { useArbiterResultDisplayState } from '../../context/AppModeStateContext';
-import { useError } from '../../context/ErrorContext';
 import { colours } from '../../style/colour';
-import { isError } from '../../types/Result';
 import { chessGameIdentifier } from '../../util/chessGameInfo';
 import { styles } from './style';
 
@@ -17,55 +13,16 @@ const ArbiterResultDisplay: React.FC = () => {
   const arbiterResultDisplayState = useArbiterResultDisplayState();
   const arbiterResultDisplayMode = arbiterResultDisplayState?.[0];
 
-  const goBackToRecordingMode =
-    arbiterResultDisplayState?.[1].goBackToRecordingMode;
-  const goBackToEnterPgn = arbiterResultDisplayState?.[1].goBackToEnterPgn;
-
-  const [showOption, setShowOption] = useState(false);
-  const [, showError] = useError();
-
   const infoString = `Board ${
     arbiterResultDisplayMode?.pairing
       ? chessGameIdentifier(arbiterResultDisplayMode?.pairing)
       : '[Unknown Game]'
   }`;
 
-  const handleBackToPgn = () => {
-    setShowOption(false);
-
-    if (goBackToEnterPgn) {
-      goBackToEnterPgn();
-    }
-  };
-
-  const handleBackToRecordingMode = async (): Promise<void> => {
-    setShowOption(false);
-
-    // if error occurs while fetching pairings, show error
-    if (goBackToRecordingMode) {
-      const result = await goBackToRecordingMode();
-      if (isError(result)) {
-        showError(result.error);
-      }
-    }
-  };
-
   return (
     <>
       {arbiterResultDisplayMode && (
         <View style={styles.container}>
-          <OptionSheet
-            message={'Return to:'}
-            options={[
-              { text: 'Enter PGN', onPress: handleBackToPgn },
-              {
-                text: 'Recording Mode',
-                onPress: async () => await handleBackToRecordingMode(),
-              },
-            ]}
-            onCancel={() => setShowOption(false)}
-            visible={showOption}
-          />
           <PrimaryText
             weight={FontWeight.Regular}
             size={70}
@@ -96,12 +53,6 @@ const ArbiterResultDisplay: React.FC = () => {
                   ? 1
                   : 0
               }
-            />
-          </View>
-          <View style={styles.arbiterButtonContainer}>
-            <PrimaryButton
-              label="go back"
-              onPress={() => setShowOption(true)}
             />
           </View>
         </View>

--- a/packages/TorneloScoresheet/src/pages/TablePairing/ArbiterTablePairing.tsx
+++ b/packages/TorneloScoresheet/src/pages/TablePairing/ArbiterTablePairing.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useArbiterTablePairingState } from '../../context/AppModeStateContext';
 import { styles } from './style';
 import { View } from 'react-native';
@@ -8,63 +8,20 @@ import PrimaryText, {
 } from '../../components/PrimaryText/PrimaryText';
 import { colours } from '../../style/colour';
 import { chessGameIdentifier } from '../../util/chessGameInfo';
-import PrimaryButton from '../../components/PrimaryButton/PrimaryButton';
-import { isError } from '../../types/Result';
-import { useError } from '../../context/ErrorContext';
-import OptionSheet from '../../components/OptionSheet/OptionSheet';
 
 const ArbiterTablePairing: React.FC = () => {
   const arbiterTablePairingState = useArbiterTablePairingState();
   const tablePairingMode = arbiterTablePairingState?.[0];
-  const goBackToEnterPgn = arbiterTablePairingState?.[1].goBackToEnterPgn;
-  const goBackToPairingSelection =
-    arbiterTablePairingState?.[1].goBackToPairingSelectionMode;
-  const [, showError] = useError();
-  const [showOption, setShowOption] = useState(false);
-
   const infoString = `Board ${
     tablePairingMode?.pairing
       ? chessGameIdentifier(tablePairingMode?.pairing)
       : '[Unknown Game]'
   }`;
 
-  const handleBackToPgn = () => {
-    setShowOption(false);
-
-    if (goBackToEnterPgn) {
-      goBackToEnterPgn();
-    }
-  };
-
-  const handleBackToPairingSelection = async () => {
-    if (!goBackToPairingSelection) {
-      return;
-    }
-    setShowOption(false);
-
-    // if error occurs while fetching pairings, show error
-    const result = await goBackToPairingSelection();
-    if (isError(result)) {
-      showError(result.error);
-    }
-  };
-
   return (
     <>
       {tablePairingMode && (
         <View style={styles.container}>
-          <OptionSheet
-            message={'Return to:'}
-            options={[
-              { text: 'Enter PGN', onPress: handleBackToPgn },
-              {
-                text: 'Pairing Selection',
-                onPress: async () => await handleBackToPairingSelection(),
-              },
-            ]}
-            onCancel={() => setShowOption(false)}
-            visible={showOption}
-          />
           <PrimaryText
             weight={FontWeight.Regular}
             size={70}
@@ -76,12 +33,6 @@ const ArbiterTablePairing: React.FC = () => {
             <PlayerCard player={tablePairingMode.pairing.players[0]} />
             <View style={styles.horizontalSeparator} />
             <PlayerCard player={tablePairingMode.pairing.players[1]} />
-          </View>
-          <View style={styles.arbiterButtonsContainer}>
-            <PrimaryButton
-              label="go back"
-              onPress={() => setShowOption(true)}
-            />
           </View>
         </View>
       )}


### PR DESCRIPTION
This PR standardises the way the arbiter will navigation between app modes.
Previously some arbiter modes had a button to select which mode to return to, some arbiter modes had a back button, and some arbiter modes used a back button in the toolbar.
This PR makes it so all arbiter modes use a hamburger menu icon in the toolbar to select which mode to go to.
This opens an option sheet that the arbiter can use to select which app mode they want to move to 

This PR also removed the transition functions from the toolbar hook and moved them to the respective app mode hooks, which makes stuff much cleaner by avoiding the if else statements in the toolbar state to find out which app mode we are in 

https://user-images.githubusercontent.com/26475724/196017736-44c6290c-7cec-4d6b-bb1d-b292b47b59de.mp4

