### PR TITLE
added labels to text input boxes

### DIFF
--- a/packages/TorneloScoresheet/src/pages/EnterPgn/EditCurrentEvent.tsx
+++ b/packages/TorneloScoresheet/src/pages/EnterPgn/EditCurrentEvent.tsx
@@ -163,13 +163,20 @@ const EditCurrentEvent: React.FC<EditCurrentEventParams> = ({
               <View style={styles.informationAndInputBoxContainer}>
                 <View style={styles.inputBoxesContainer}>
                   {inputBoxesContent.map((inputBoxContent, key) => (
-                    <InputBox
-                      key={key}
-                      style={styles.inputBox}
-                      value={inputBoxContent[0]}
-                      onChangeText={inputBoxContent[1]}
-                      placeholder={inputBoxContent[2]}
-                    />
+                    <>
+                      <PrimaryText
+                        size={30}
+                        weight={FontWeight.SemiBold}
+                        label={inputBoxContent[2]}
+                      />
+                      <InputBox
+                        key={key}
+                        style={styles.inputBox}
+                        value={inputBoxContent[0]}
+                        onChangeText={inputBoxContent[1]}
+                        placeholder={inputBoxContent[2]}
+                      />
+                    </>
                   ))}
                 </View>
               </View>

--- a/packages/TorneloScoresheet/src/pages/EnterPgn/EditCurrentEvent.tsx
+++ b/packages/TorneloScoresheet/src/pages/EnterPgn/EditCurrentEvent.tsx
@@ -163,20 +163,19 @@ const EditCurrentEvent: React.FC<EditCurrentEventParams> = ({
               <View style={styles.informationAndInputBoxContainer}>
                 <View style={styles.inputBoxesContainer}>
                   {inputBoxesContent.map((inputBoxContent, key) => (
-                    <>
+                    <View key={key}>
                       <PrimaryText
                         size={30}
                         weight={FontWeight.SemiBold}
                         label={inputBoxContent[2]}
                       />
                       <InputBox
-                        key={key}
                         style={styles.inputBox}
                         value={inputBoxContent[0]}
                         onChangeText={inputBoxContent[1]}
                         placeholder={inputBoxContent[2]}
                       />
-                    </>
+                    </View>
                   ))}
                 </View>
               </View>

--- a/packages/TorneloScoresheet/src/pages/EnterPgn/style.ts
+++ b/packages/TorneloScoresheet/src/pages/EnterPgn/style.ts
@@ -116,7 +116,8 @@ export const styles = StyleSheet.create({
   inputBox: {
     fontSize: 23,
     padding: 23,
-    marginTop: 29,
+    marginTop: 10,
+    marginBottom: 20,
     width: 600,
   },
   inputBoxesContainer: {


### PR DESCRIPTION
I noticed that when the event text input boxes were all full there was no way of knowing which input was which because the labels only appeared when the input was empty.

<img width="222" alt="image" src="https://user-images.githubusercontent.com/64511606/196592048-f1834f70-f789-4112-b65e-0a81406fe9ed.png">
<img width="230" alt="image" src="https://user-images.githubusercontent.com/64511606/196592149-841da367-3f26-46e2-9542-550ca63b2e02.png">
