### PR TITLE
Fix general settings loading bug

### DIFF
--- a/packages/TorneloScoresheet/src/components/SettingsSheet/SettingsSheet.tsx
+++ b/packages/TorneloScoresheet/src/components/SettingsSheet/SettingsSheet.tsx
@@ -3,6 +3,7 @@ import { View } from 'react-native';
 import DropDownPicker from 'react-native-dropdown-picker';
 import { useGeneralSettings } from '../../context/GeneralSettingsContext';
 import { ChessPieceStyles } from '../../types/GeneralSettingsState';
+import PrimaryButton from '../PrimaryButton/PrimaryButton';
 import PrimaryText, { FontWeight } from '../PrimaryText/PrimaryText';
 import Sheet from '../Sheet/Sheet';
 import { styles } from './style';
@@ -15,19 +16,24 @@ export type SettingsSheetProps = {
 const SettingsSheet: React.FC<SettingsSheetProps> = ({ visible, onCancel }) => {
   const [generalSettings, setGeneralSettings] = useGeneralSettings();
 
-  // Chess Piece Style
+  const saveSettings = async () => {
+    await setGeneralSettings({
+      chessPieceStyle: pieceStyle,
+    });
+    onCancel();
+  };
+
+  // -----  Chess Piece Style
   const [openPieceStyle, setOpenPieceStyle] = useState(false);
   const pieceStyleOptions = [
     { label: 'Tornelo', value: ChessPieceStyles.TORNELO },
     { label: 'Classic', value: ChessPieceStyles.CLASSIC },
   ];
   const [pieceStyle, setPieceStyle] = useState(generalSettings.chessPieceStyle);
-
+  // update piece style form value once settings load from disk
   useEffect(() => {
-    setGeneralSettings({
-      chessPieceStyle: pieceStyle,
-    });
-  }, [pieceStyle]);
+    setPieceStyle(generalSettings.chessPieceStyle);
+  }, [generalSettings]);
 
   return (
     <Sheet visible={visible} dismiss={onCancel} title="General Settings">
@@ -49,6 +55,12 @@ const SettingsSheet: React.FC<SettingsSheetProps> = ({ visible, onCancel }) => {
             textStyle={styles.settingText}
           />
         </View>
+        <PrimaryButton
+          label="save"
+          onPress={saveSettings}
+          style={styles.saveButton}
+          labelStyle={styles.buttonText}
+        />
       </View>
     </Sheet>
   );

--- a/packages/TorneloScoresheet/src/components/SettingsSheet/style.ts
+++ b/packages/TorneloScoresheet/src/components/SettingsSheet/style.ts
@@ -18,6 +18,14 @@ export const styles = StyleSheet.create({
     fontFamily: primary,
     fontWeight: FontWeight.SemiBold,
   },
+  buttonText: {
+    fontSize: 25,
+  },
+  saveButton: {
+    minWidth: 200,
+    height: 70,
+    marginTop: 50,
+  },
   inputBoxesContainer: {
     display: 'flex',
     flexDirection: 'row',


### PR DESCRIPTION
There was a bug with the general settings where the settings were not saved after closing the app.

Actually the settings were being saved, but were overriden by the settings sheet at the start due to calling useEffect() for both the settings context and the settings sheet (the sheet would finish first since it is not async, and would then ovveride the saved settings).
To avoid this problem, we will only store the settings after pressing save