### PR TITLE
Separate Staging and production environents

### DIFF
--- a/packages/TorneloScoresheet/package-lock.json
+++ b/packages/TorneloScoresheet/package-lock.json
@@ -12,6 +12,7 @@
         "axios": "^0.26.1",
         "chess.ts": "file:../chess.ts",
         "country-iso-3-to-2": "^1.1.1",
+        "env-cmd": "^10.1.0",
         "moment": "^2.29.4",
         "qs": "^6.11.0",
         "react": "17.0.2",
@@ -11496,7 +11497,6 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -11509,7 +11509,6 @@
     },
     "node_modules/cross-spawn/node_modules/path-key": {
       "version": "3.1.1",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11937,6 +11936,29 @@
       "license": "BSD-2-Clause",
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-cmd": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-10.1.0.tgz",
+      "integrity": "sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==",
+      "dependencies": {
+        "commander": "^4.0.0",
+        "cross-spawn": "^7.0.0"
+      },
+      "bin": {
+        "env-cmd": "bin/env-cmd.js"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/env-cmd/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/envinfo": {
@@ -17784,7 +17806,6 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -17795,7 +17816,6 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -18957,7 +18977,6 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -26706,7 +26725,6 @@
     },
     "cross-spawn": {
       "version": "7.0.3",
-      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -26714,8 +26732,7 @@
       },
       "dependencies": {
         "path-key": {
-          "version": "3.1.1",
-          "dev": true
+          "version": "3.1.1"
         }
       }
     },
@@ -26978,6 +26995,22 @@
     },
     "entities": {
       "version": "2.2.0"
+    },
+    "env-cmd": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/env-cmd/-/env-cmd-10.1.0.tgz",
+      "integrity": "sha512-mMdWTT9XKN7yNth/6N6g2GuKuJTsKMDHlQFUDacb/heQRRWOTIZ42t1rMHnQu4jYxU1ajdTeJM+9eEETlqToMA==",
+      "requires": {
+        "commander": "^4.0.0",
+        "cross-spawn": "^7.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
+        }
+      }
     },
     "envinfo": {
       "version": "7.8.1"
@@ -30841,14 +30874,12 @@
     },
     "shebang-command": {
       "version": "2.0.0",
-      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
     },
     "shebang-regex": {
-      "version": "3.0.0",
-      "dev": true
+      "version": "3.0.0"
     },
     "shell-quote": {
       "version": "1.7.3"
@@ -31620,7 +31651,6 @@
     },
     "which": {
       "version": "2.0.2",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/packages/TorneloScoresheet/package.json
+++ b/packages/TorneloScoresheet/package.json
@@ -4,8 +4,11 @@
   "private": true,
   "scripts": {
     "android": "react-native run-android",
+    "android:stag": "env-cmd -f stag.env react-native run-android",
     "ios": "react-native run-ios --simulator=\"iPad mini (6th generation)\"",
+    "ios:stag": "env-cmd -f stag.env react-native run-ios --simulator=\"iPad mini (6th generation)\"",
     "start": "react-native start",
+    "start:stag": "env-cmd -f stag.env react-native start",
     "test": "jest",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
@@ -14,6 +17,7 @@
     "axios": "^0.26.1",
     "chess.ts": "file:../chess.ts",
     "country-iso-3-to-2": "^1.1.1",
+    "env-cmd": "^10.1.0",
     "moment": "^2.29.4",
     "qs": "^6.11.0",
     "react": "17.0.2",

--- a/packages/TorneloScoresheet/stag.env
+++ b/packages/TorneloScoresheet/stag.env
@@ -1,0 +1,3 @@
+REACT_APP_TORNELO_URL="https://staging.tornelo.com/"
+REACT_APP_MAX_PAST_GAME_STORED=15
+REACT_APP_EMAIL_API_ENDPOINT="https://staging-api.tornelo.com/api/arbiter/USER_ID/notify-game/"


### PR DESCRIPTION
This PR implements separating the staging and prod environments

There are now 2 env files:
-staging.env - has the staging variables
-.env - has the production variables

I also added scripts in package.json to run the app using the staging variables