### PR TITLE
Attempt to fix the move list not scrolling issue

### DIFF
--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/GraphicalRecording.tsx
@@ -258,7 +258,8 @@ const GraphicalRecording: React.FC = () => {
           <ScrollView
             ref={scrollRef}
             horizontal
-            style={styles.moveCardContainer}>
+            style={styles.moveCardContainer}
+            contentContainerStyle={styles.moveCardContentContainer}>
             {plysToMoves(recordingMode.moveHistory).map((move, index) => (
               <MoveCard
                 key={index}

--- a/packages/TorneloScoresheet/src/pages/GraphicalRecording/style.ts
+++ b/packages/TorneloScoresheet/src/pages/GraphicalRecording/style.ts
@@ -6,6 +6,9 @@ export const styles = StyleSheet.create({
     display: 'flex',
     height: pageHeight,
   },
+  moveCardContentContainer: {
+    flexGrow: 1,
+  },
   verticalSeparator: {
     borderLeftColor: 'black',
     borderLeftWidth: 1,


### PR DESCRIPTION
I am unable to replicate the issue on the android emulator however multiple sources online also claim the react's `scrollToEnd` function is not working for them and that the fix is to add flexGrow to the Scrollview so hopefuly that fixes our issue.
I cannot test this on Ios as i do not have a mac :(